### PR TITLE
Encrypted EBS Volumes and Admin Users MFA tests

### DIFF
--- a/aws/client.py
+++ b/aws/client.py
@@ -209,8 +209,8 @@ class BotocoreClient:
                 keyed_result = result[key]
                 if isinstance(keyed_result, list):
                     for item in keyed_result:
-                        # TODO: Is there a bug in usage (IAM resources) causing it
-                        # to sometimes be a string?
+                        # Added for IAM inline policies call, as it
+                        # returns a list of strings.
                         if not isinstance(item, str):
                             item['__pytest_meta'] = result['__pytest_meta']
                 elif isinstance(keyed_result, dict):

--- a/aws/client.py
+++ b/aws/client.py
@@ -202,7 +202,10 @@ class BotocoreClient:
                 keyed_result = result[key]
                 if isinstance(keyed_result, list):
                     for item in keyed_result:
-                        item['__pytest_meta'] = result['__pytest_meta']
+                        # TODO: Is there a bug in usage (IAM resources) causing it
+                        # to sometimes be a string?
+                        if not isinstance(item, str):
+                            item['__pytest_meta'] = result['__pytest_meta']
                 elif isinstance(keyed_result, dict):
                     keyed_result['__pytest_meta'] = result['__pytest_meta']
 

--- a/aws/client.py
+++ b/aws/client.py
@@ -11,6 +11,9 @@ import botocore.exceptions
 import botocore.session
 
 
+SERVICES_WITHOUT_REGIONS = ["iam"]
+
+
 @functools.lru_cache()
 def get_session(profile=None):
     """Returns a new or cached botocore session for the AWS profile."""
@@ -163,6 +166,10 @@ class BotocoreClient:
             profiles=None,
             regions=None,
             result_from_error=None):
+
+        if service_name in SERVICES_WITHOUT_REGIONS:
+            regions = ["us-east-1"]
+
         self.results = list(get_aws_resource(
             service_name,
             method_name,

--- a/aws/client.py
+++ b/aws/client.py
@@ -11,7 +11,7 @@ import botocore.exceptions
 import botocore.session
 
 
-SERVICES_WITHOUT_REGIONS = ["iam"]
+SERVICES_WITHOUT_REGIONS = ["iam", "s3"]
 
 
 @functools.lru_cache()

--- a/aws/client.py
+++ b/aws/client.py
@@ -167,6 +167,11 @@ class BotocoreClient:
             regions=None,
             result_from_error=None):
 
+        # TODO:
+        # For services that don't have the concept of regions,
+        # we don't want to do the exact same test N times where
+        # N is the number of regions. But the below hardcoding
+        # is not a very clean solution to this.
         if service_name in SERVICES_WITHOUT_REGIONS:
             regions = ["us-east-1"]
 

--- a/aws/ec2/resources.py
+++ b/aws/ec2/resources.py
@@ -10,3 +10,11 @@ def ec2_security_groups():
       .extract_key('SecurityGroups')\
       .flatten()\
       .values()
+
+def ec2_ebs_volumes():
+    "http://botocore.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.describe_volumes"
+    return botocore_client\
+      .get('ec2', 'describe_volumes', [], {})\
+      .extract_key('Volumes')\
+      .flatten()\
+      .values()

--- a/aws/ec2/test_ec2_ebs_volume_encrypted.py
+++ b/aws/ec2/test_ec2_ebs_volume_encrypted.py
@@ -3,6 +3,26 @@ import pytest
 from aws.ec2.resources import ec2_ebs_volumes
 
 def is_ebs_volume_encrypted(ec2_ebs_volume):
+    """
+    Checks the EBS volume 'Encrypted' value.
+
+    >>> is_ebs_volume_encrypted({'Encrypted': True})
+    True
+    >>> is_ebs_volume_encrypted({'Encrypted': False})
+    False
+    >>> is_ebs_volume_encrypted({})
+    Traceback (most recent call last):
+    ...
+    KeyError: 'StorageEncrypted'
+    >>> is_ebs_volume_encrypted(0)
+    Traceback (most recent call last):
+    ...
+    TypeError: 'int' object is not subscriptable
+    >>> is_ebs_volume_encrypted(None)
+    Traceback (most recent call last):
+    ...
+    TypeError: 'NoneType' object is not subscriptable
+    """
     return bool(ec2_ebs_volume['Encrypted'])
 
 @pytest.mark.ec2

--- a/aws/ec2/test_ec2_ebs_volume_encrypted.py
+++ b/aws/ec2/test_ec2_ebs_volume_encrypted.py
@@ -13,7 +13,7 @@ def is_ebs_volume_encrypted(ec2_ebs_volume):
     >>> is_ebs_volume_encrypted({})
     Traceback (most recent call last):
     ...
-    KeyError: 'StorageEncrypted'
+    KeyError: 'Encrypted'
     >>> is_ebs_volume_encrypted(0)
     Traceback (most recent call last):
     ...

--- a/aws/ec2/test_ec2_ebs_volume_encrypted.py
+++ b/aws/ec2/test_ec2_ebs_volume_encrypted.py
@@ -1,0 +1,11 @@
+import pytest
+
+from aws.ec2.resources import ec2_ebs_volumes
+
+def is_ebs_volume_encrypted(ec2_ebs_volume):
+    return bool(ec2_ebs_volume['Encrypted'])
+
+@pytest.mark.ec2
+@pytest.mark.parametrize('ec2_ebs_volume', ec2_ebs_volumes())
+def test_ec2_ebs_volume_encrypted(ec2_ebs_volume):
+    assert is_ebs_volume_encrypted(ec2_ebs_volume)

--- a/aws/iam/resources.py
+++ b/aws/iam/resources.py
@@ -72,12 +72,12 @@ def iam_all_user_policies(username):
             if isinstance(policy_name, str):
                 inline += {'PolicyName': policy_name}
 
-
     managed = [
         policy for policies in
         iam_managed_policies(username=username) + iam_user_group_managed_policies(username=username)
         for policy in policies
     ]
+
     return inline + managed
 
 def iam_users_with_policies():

--- a/aws/iam/resources.py
+++ b/aws/iam/resources.py
@@ -1,0 +1,36 @@
+from conftest import botocore_client
+
+def iam_users():
+    "http://botocore.readthedocs.io/en/latest/reference/services/iam.html#IAM.Client.list_users"
+    return botocore_client\
+      .get('iam', 'list_users', [], {})\
+      .extract_key('Users')\
+      .flatten()\
+      .values()
+
+def iam_login_profiles():
+    "http://botocore.readthedocs.io/en/latest/reference/services/iam.html#IAM.Client.get_login_profile"
+    return [
+        botocore_client\
+        .get('iam',
+             'get_login_profile',
+             [],
+             {'UserName': user['UserName']},
+             result_from_error=lambda error, call: {'LoginProfile': None})\
+        .extract_key('LoginProfile')\
+        .values()[0]
+        for user in iam_users()
+    ]
+
+def iam_mfa_devices():
+    "botocore.readthedocs.io/en/latest/reference/services/iam.html#IAM.Client.list_mfa_devices"
+    return [
+        botocore_client\
+        .get('iam',
+             'list_mfa_devices',
+             [],
+             {'UserName': user['UserName']})\
+        .extract_key('MFADevices')\
+        .values()[0]
+        for user in iam_users()
+    ]

--- a/aws/iam/resources.py
+++ b/aws/iam/resources.py
@@ -8,6 +8,113 @@ def iam_users():
       .flatten()\
       .values()
 
+def iam_inline_policies(username):
+    "http://botocore.readthedocs.io/en/latest/reference/services/iam.html#IAM.Client.list_user_policies"
+    return botocore_client\
+      .get('iam', 'list_user_policies', [], {'UserName': username})\
+      .extract_key('PolicyNames')\
+      .flatten()\
+      .values()
+
+def iam_managed_policies(username):
+    "http://botocore.readthedocs.io/en/latest/reference/services/iam.html#IAM.Client.list_attached_user_policies"
+    return botocore_client\
+      .get('iam', 'list_attached_user_policies', [], {'UserName': username})\
+      .extract_key('AttachedPolicies')\
+      .flatten()\
+      .values()
+
+def iam_user_groups(username):
+    "http://botocore.readthedocs.io/en/latest/reference/services/iam.html#IAM.Client.list_groups_for_user"
+    return botocore_client\
+      .get('iam', 'list_groups_for_user', [], {'UserName': username})\
+      .extract_key('Groups')\
+      .flatten()\
+      .values()
+
+def iam_user_group_inline_policies(username):
+    "http://botocore.readthedocs.io/en/latest/reference/services/iam.html#IAM.Client.list_group_policies"
+    return [
+        botocore_client\
+        .get('iam', 'list_group_policies', [], {'GroupName': group['GroupName']})\
+        .extract_key('PolicyNames')\
+        .flatten()\
+        .values()
+        for group in iam_user_groups(username)
+    ]
+
+def iam_user_group_managed_policies(username):
+    "http://botocore.readthedocs.io/en/latest/reference/services/iam.html#IAM.Client.list_attached_group_policies"
+    return [
+        botocore_client\
+        .get('iam', 'list_attached_group_policies', [], {'GroupName': group['GroupName']})\
+        .extract_key('AttachedPolicies')\
+        .flatten()\
+        .values()
+        for group in iam_user_groups(username)
+    ]
+
+def iam_all_user_policies(username):
+    '''
+    Gets all policies that can be attached to a user. This includes:
+        - Inline policies on the user
+        - Managed policies on the user
+        - Inline policies on the group that the user is in
+        - Managed policies on the group that the user is in
+
+    Inline policy API calls just return the name of the policy, so we create a single key dictionary to
+    allow for standard access to the policy name ({'PolicyName': policy_name})
+    '''
+    inline = []
+    inline_policies = [iam_inline_policies(username=username) + iam_user_group_inline_policies(username=username)]
+    for policies in inline_policies:
+        for policy_name in policies:
+            if isinstance(policy_name, str):
+                inline += {'PolicyName': policy_name}
+
+
+    managed = [
+        policy for policies in
+        iam_managed_policies(username=username) + iam_user_group_managed_policies(username=username)
+        for policy in policies
+    ]
+    return inline + managed
+
+def iam_users_with_policies():
+    return [
+        {
+            'Policies': iam_all_user_policies(username=user['UserName']),
+            'User': user,
+        } for user in iam_users()
+    ]
+
+def iam_admin_login_profiles():
+    "http://botocore.readthedocs.io/en/latest/reference/services/iam.html#IAM.Client.get_login_profile"
+    return [
+        botocore_client\
+        .get('iam',
+             'get_login_profile',
+             [],
+             {'UserName': user['User']['UserName']},
+             result_from_error=lambda error, call: {'LoginProfile': None})\
+        .extract_key('LoginProfile')\
+        .values()[0]
+        for user in iam_users_with_policies() if user_is_admin(user)
+    ]
+
+def iam_admin_mfa_devices():
+    "botocore.readthedocs.io/en/latest/reference/services/iam.html#IAM.Client.list_mfa_devices"
+    return [
+        botocore_client\
+        .get('iam',
+             'list_mfa_devices',
+             [],
+             {'UserName': user['User']['UserName']})\
+        .extract_key('MFADevices')\
+        .values()[0]
+        for user in iam_users_with_policies() if user_is_admin(user)
+    ]
+
 def iam_login_profiles():
     "http://botocore.readthedocs.io/en/latest/reference/services/iam.html#IAM.Client.get_login_profile"
     return [
@@ -34,3 +141,15 @@ def iam_mfa_devices():
         .values()[0]
         for user in iam_users()
     ]
+
+#FIXME
+# Substring matching is _not_ enough of a check, but works for testing.
+# The truth is that we probably shouldn't depend too much on the concept
+# of an "admin" in AWS, since that's not how the ACL's really work. We
+# should probably move towards concepts like "has write access", "can
+# read secrets", etc.
+def user_is_admin(user):
+    for policy in user['Policies']:
+        if isinstance(policy, dict):
+            if 'admin' in policy.get('PolicyName', '').lower():
+                return True

--- a/aws/iam/test_iam_admin_user_without_mfa.py
+++ b/aws/iam/test_iam_admin_user_without_mfa.py
@@ -12,4 +12,5 @@ from aws.iam.resources import (
         ids=lambda login: login['UserName'])
 def test_iam_admin_user_without_mfa(iam_login_profile, iam_user_mfa_devices):
     if bool(iam_login_profile):
-        assert len(iam_user_mfa_devices) > 0
+        assert len(iam_user_mfa_devices) > 0, \
+            'No MFA Device found for {}'.format(iam_login_profile['UserName'])

--- a/aws/iam/test_iam_admin_user_without_mfa.py
+++ b/aws/iam/test_iam_admin_user_without_mfa.py
@@ -1,15 +1,15 @@
 import pytest
 
 from aws.iam.resources import (
-    iam_login_profiles,
-    iam_mfa_devices,
+    iam_admin_login_profiles,
+    iam_admin_mfa_devices,
 )
 
 @pytest.mark.iam
 @pytest.mark.parametrize(
         ['iam_login_profile', 'iam_user_mfa_devices'],
-        zip(iam_login_profiles(), iam_mfa_devices()),
+        zip(iam_admin_login_profiles(), iam_admin_mfa_devices()),
         ids=lambda login: login['UserName'])
-def test_iam_user_without_mfa(iam_login_profile, iam_user_mfa_devices):
+def test_iam_admin_user_without_mfa(iam_login_profile, iam_user_mfa_devices):
     if bool(iam_login_profile):
         assert len(iam_user_mfa_devices) > 0

--- a/aws/iam/test_iam_user_without_mfa.py
+++ b/aws/iam/test_iam_user_without_mfa.py
@@ -1,0 +1,15 @@
+import pytest
+
+from aws.iam.resources import (
+    iam_login_profiles,
+    iam_mfa_devices,
+)
+
+@pytest.mark.iam
+@pytest.mark.parametrize(
+        ['iam_login_profile', 'iam_user_mfa_devices'],
+        zip(iam_login_profiles(), iam_mfa_devices()),
+        ids=lambda login: login['UserName'])
+def test_iam_user_without_mfa(iam_login_profile, iam_user_mfa_devices):
+    if bool(iam_login_profile):
+        assert len(iam_user_mfa_devices) > 0


### PR DESCRIPTION
This PR adds two tests:

- test_ec2_ebs_volume_encrypted
- test_iam_admin_user_without_mfa

We will want to eventually change `test_iam_admin_user_without_mfa` to test for all users that can log in, but for now this is a nice scoping.

### Discussion

If you look at the `user_is_admin` function, there is a comment block above it:
```
# FIXME
# Substring matching is _not_ enough of a check, but works for testing.
# The truth is that we probably shouldn't depend too much on the concept
# of an "admin" in AWS, since that's not how the ACL's really work. We
# should probably move towards concepts like "has write access", "can
# read secrets", etc.
```

Something I'd like to discuss is whether attempting to scope to the concept of an "Admin" via policies is ok for now or if this should get more flushed out at this point.