### PR TITLE
Improve Reporting for AWS

### DIFF
--- a/aws/ec2/test_ec2_security_group_all_ports.py
+++ b/aws/ec2/test_ec2_security_group_all_ports.py
@@ -26,7 +26,8 @@ def ec2_security_group_has_all_ports(ec2_security_group):
 
 
 @pytest.mark.ec2
-@pytest.mark.xfail
-@pytest.mark.parametrize('ec2_security_group', ec2_security_groups())
+@pytest.mark.parametrize('ec2_security_group',
+                         ec2_security_groups(),
+                         ids=lambda secgroup: secgroup['GroupName'])
 def test_ec2_security_group_all_ports(ec2_security_group):
     assert not ec2_security_group_has_all_ports(ec2_security_group)

--- a/aws/rds/resources.py
+++ b/aws/rds/resources.py
@@ -11,6 +11,20 @@ def rds_db_instances():
       .flatten()\
       .values()
 
+def rds_db_instance_tags(dbname):
+    "http://botocore.readthedocs.io/en/latest/reference/services/rds.html#RDS.Client.list_tags_for_resource"
+    return botocore_client\
+      .get('rds', 'list_tags_for_resource', [], {'ResourceName': dbname})\
+      .extract_key('TagList')\
+      .flatten()\
+      .values()
+
+def rds_db_instances_with_tags():
+    return [
+        {**{'TagList': rds_db_instance_tags(dbname=db['DBInstanceArn'])}, **db}
+        for db in rds_db_instances()
+    ]
+
 
 def rds_db_instance_db_security_groups():
     "http://botocore.readthedocs.io/en/latest/reference/services/rds.html#RDS.Client.describe_db_security_groups"

--- a/aws/rds/test_rds_db_instance_backup_enabled.py
+++ b/aws/rds/test_rds_db_instance_backup_enabled.py
@@ -1,12 +1,12 @@
 
 import pytest
 
-from aws.rds.resources import rds_db_instances
+from aws.rds.resources import rds_db_instances_with_tags
 
 
 @pytest.mark.rds
 @pytest.mark.parametrize('rds_db_instance',
-                         rds_db_instances(),
+                         rds_db_instances_with_tags(),
                          ids=lambda db_instance: db_instance['DBInstanceIdentifier'])
 def test_rds_db_instance_backup_enabled(rds_db_instance):
     assert rds_db_instance['BackupRetentionPeriod'] > 0, \

--- a/aws/rds/test_rds_db_instance_encrypted.py
+++ b/aws/rds/test_rds_db_instance_encrypted.py
@@ -1,7 +1,7 @@
 
 import pytest
 
-from aws.rds.resources import rds_db_instances
+from aws.rds.resources import rds_db_instances_with_tags
 
 
 def is_rds_db_instance_encrypted(rds_db_instance):
@@ -30,7 +30,7 @@ def is_rds_db_instance_encrypted(rds_db_instance):
 
 @pytest.mark.rds
 @pytest.mark.parametrize('rds_db_instance',
-                         rds_db_instances(),
+                         rds_db_instances_with_tags(),
                          ids=lambda db_instance: db_instance['DBInstanceIdentifier'])
 def test_rds_db_instance_encrypted(rds_db_instance):
     assert is_rds_db_instance_encrypted(rds_db_instance)

--- a/aws/rds/test_rds_db_instance_is_multiaz.py
+++ b/aws/rds/test_rds_db_instance_is_multiaz.py
@@ -1,12 +1,12 @@
 
 import pytest
 
-from aws.rds.resources import rds_db_instances
+from aws.rds.resources import rds_db_instances_with_tags
 
 
 @pytest.mark.rds
 @pytest.mark.parametrize('rds_db_instance',
-                         rds_db_instances(),
+                         rds_db_instances_with_tags(),
                          ids=lambda db_instance: db_instance['DBInstanceIdentifier'])
 def test_rds_db_instance_is_multiaz(rds_db_instance):
     assert rds_db_instance['MultiAZ'] == False, '{} is in a single availability zone'.format(rds_db_instance['DBInstanceIdentifier'])

--- a/aws/rds/test_rds_db_instance_is_postgres_with_invalid_certificate.py
+++ b/aws/rds/test_rds_db_instance_is_postgres_with_invalid_certificate.py
@@ -5,12 +5,12 @@ from botocore.utils import parse_timestamp
 
 import pytest
 
-from aws.rds.resources import rds_db_instances
+from aws.rds.resources import rds_db_instances_with_tags
 
 
 @pytest.mark.rds
 @pytest.mark.parametrize('rds_db_instance',
-                         rds_db_instances(),
+                         rds_db_instances_with_tags(),
                          ids=lambda db_instance: db_instance['DBInstanceIdentifier'])
 def test_rds_db_instance_is_postgres_with_invalid_certificate(rds_db_instance):
     if rds_db_instance['Engine'] != 'postgres':

--- a/aws/rds/test_rds_db_instance_minor_version_updates_enabled.py
+++ b/aws/rds/test_rds_db_instance_minor_version_updates_enabled.py
@@ -1,12 +1,12 @@
 
 import pytest
 
-from aws.rds.resources import rds_db_instances
+from aws.rds.resources import rds_db_instances_with_tags
 
 
 @pytest.mark.rds
 @pytest.mark.parametrize('rds_db_instance',
-                         rds_db_instances(),
+                         rds_db_instances_with_tags(),
                          ids=lambda db_instance: db_instance['DBInstanceIdentifier'])
 def test_rds_db_instance_minor_version_updates_enabled(rds_db_instance):
     """

--- a/aws/rds/test_rds_db_instance_not_publicly_accessible_by_rds_db_sg.py
+++ b/aws/rds/test_rds_db_instance_not_publicly_accessible_by_rds_db_sg.py
@@ -2,7 +2,7 @@
 import pytest
 
 from aws.rds.resources import (
-    rds_db_instances,
+    rds_db_instances_with_tags,
     rds_db_instance_db_security_groups,
 )
 from .test_rds_db_security_group_does_not_grant_public_access import does_rds_db_security_group_grant_public_access
@@ -11,7 +11,7 @@ from .test_rds_db_security_group_does_not_grant_public_access import does_rds_db
 @pytest.mark.rds
 @pytest.mark.parametrize(
     ['rds_db_instance', 'rds_db_security_groups'],
-    zip(rds_db_instances(), rds_db_instance_db_security_groups()),
+    zip(rds_db_instances_with_tags(), rds_db_instance_db_security_groups()),
     ids=lambda db_instance: db_instance['DBInstanceIdentifier']
 )
 def test_rds_db_instance_not_publicly_accessible_by_rds_db_security_group(rds_db_instance, rds_db_security_groups):

--- a/aws/rds/test_rds_db_instance_not_publicly_accessible_by_vpc_sg.py
+++ b/aws/rds/test_rds_db_instance_not_publicly_accessible_by_vpc_sg.py
@@ -2,7 +2,7 @@
 import pytest
 
 from aws.rds.resources import (
-    rds_db_instances,
+    rds_db_instances_with_tags,
     rds_db_instances_vpc_security_groups,
 )
 
@@ -25,7 +25,7 @@ IPRanges": []})
 @pytest.mark.rds
 @pytest.mark.parametrize(
     ['rds_db_instance', 'ec2_security_groups'],
-    zip(rds_db_instances(), rds_db_instances_vpc_security_groups()),
+    zip(rds_db_instances_with_tags(), rds_db_instances_vpc_security_groups()),
     ids=lambda db_instance: db_instance['DBInstanceIdentifier']
 )
 def test_rds_db_instance_not_publicly_accessible_by_vpc_security_group(rds_db_instance, ec2_security_groups):

--- a/conftest.py
+++ b/conftest.py
@@ -67,7 +67,7 @@ def extract_metadata(resource):
       if metadata_key in resource
     }
 
-def process_funcargs(funcargs):
+def get_metadata_from_funcargs(funcargs):
     metadata = {}
     for k in funcargs:
         if isinstance(funcargs[k], dict):
@@ -112,7 +112,7 @@ def pytest_runtest_makereport(item, call):
 
     # only add this during call instead of during any stage
     if report.when == 'call':
-        metadata = process_funcargs(item.funcargs)
+        metadata = get_metadata_from_funcargs(item.funcargs)
         markers = {k: serialize_marker(v) for (k, v) in get_node_markers(item).items()}
         outcome, reason = get_outcome_and_reason(report, markers, call)
 

--- a/conftest.py
+++ b/conftest.py
@@ -67,11 +67,11 @@ def extract_metadata(resource):
       if metadata_key in resource
     }
 
-def process_funcargs(keys, funcargs):
+def process_funcargs(funcargs):
     metadata = {}
-    for key in keys:
-        if isinstance(funcargs[key], dict):
-            metadata = {**metadata, **extract_metadata(funcargs[key])}
+    for k in funcargs:
+        if isinstance(funcargs[k], dict):
+            metadata = {**metadata, **extract_metadata(funcargs[k])}
     return metadata
 
 def serialize_marker(marker):
@@ -112,7 +112,7 @@ def pytest_runtest_makereport(item, call):
 
     # only add this during call instead of during any stage
     if report.when == 'call':
-        metadata = process_funcargs(item.fixturenames, item.funcargs)
+        metadata = process_funcargs(item.funcargs)
         markers = {k: serialize_marker(v) for (k, v) in get_node_markers(item).items()}
         outcome, reason = get_outcome_and_reason(report, markers, call)
 

--- a/conftest.py
+++ b/conftest.py
@@ -59,6 +59,20 @@ def pytest_configure(config):
 def get_node_markers(node):
     return {k: v for k, v in node.keywords.items() if isinstance(v, (MarkDecorator, MarkInfo))}
 
+METADATA_KEYS = ['OwnerId', 'VpcId', 'DBInstanceIdentifier', 'TagList']
+def extract_metadata(resource):
+    return {
+      metadata_key: resource[metadata_key]
+      for metadata_key in METADATA_KEYS
+      if metadata_key in resource
+    }
+
+def process_funcargs(keys, funcargs):
+    metadata = {}
+    for key in keys:
+        if isinstance(funcargs[key], dict):
+            metadata = {**metadata, **extract_metadata(funcargs[key])}
+    return metadata
 
 def serialize_marker(marker):
     if isinstance(marker, (MarkDecorator, MarkInfo)):
@@ -94,24 +108,23 @@ def pytest_runtest_makereport(item, call):
 
     outcome = yield
     report = outcome.get_result()
-    extra = getattr(report, 'extra', [])
 
-    markers = {k: serialize_marker(v) for (k, v) in get_node_markers(item).items()}
-    outcome, reason = get_outcome_and_reason(report, markers, call)
 
     # only add this during call instead of during any stage
     if report.when == 'call':
-        # item.config
+        metadata = process_funcargs(item.fixturenames, item.funcargs)
+        markers = {k: serialize_marker(v) for (k, v) in get_node_markers(item).items()}
+        outcome, reason = get_outcome_and_reason(report, markers, call)
 
         fixtures = {fixture_name: item.funcargs[fixture_name] for fixture_name in item.fixturenames if fixture_name != 'request'}
 
-
         # add json metadata
         report.test_metadata = dict(
+            fixtures=fixtures,
+            markers=markers,
+            metadata=metadata,
             outcome=outcome,  # 'passed', 'failed', 'skipped', 'xfailed', 'xskipped', or 'errored'
+            parametrized_name=item.name,
             reason=reason,
             unparametrized_name=item.originalname,
-            parametrized_name=item.name,
-            markers=markers,
-            fixtures=fixtures,
         )

--- a/report_json_to_service_json.py
+++ b/report_json_to_service_json.py
@@ -35,6 +35,7 @@ Pytest service JSON format:
        'value':
        'reason':  # pytest test outcome reason if any (e.g. resource fetch failed)
        'markers':  # pytest markers on the test e.g. aws service, ruleset
+       'metadata':  # additional metadata on the resource being tested
     },
     ...
   ]
@@ -100,12 +101,13 @@ def get_test_status(outcome):
 def get_result_for_test(test):
     meta = test['metadata'][0]
     return {
-        'test_name': meta['unparametrized_name'],  # unparametrized pytest name
+        'test_name': meta['unparametrized_name'],
         'name': meta['parametrized_name'],
         'status': get_test_status(meta['outcome']),
         'value': meta['outcome'],
-        'reason': meta['reason'],  # pytest test outcome reason if any (e.g. resource fetch failed)
-        'markers': meta['markers'],  # pytest markers on the test e.g. aws service, ruleset
+        'reason': meta['reason'],
+        'markers': meta['markers'],
+        'metadata': meta['metadata'],
     }
 
 


### PR DESCRIPTION
Adds "metadata" to the service report and fixes the parametrized_name for `test_ec2_security_group_all_ports`