### PR TITLE
Move RDS helpers to helpers.py + add 'make doctests'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ ENTER_VENV := source venv/bin/activate
 
 AWS_PROFILE := default
 
+doctest:
+	for f in $$(find . -name '*.py' | grep -vP '(venv|test|resources|init)'); do venv/bin/python -m doctest $$f; done
+
 clean: clean-cache
 
 clean-cache:

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ freshness](#5)).
 Additionally we want:
 
 * data fetching functions in a `resources.py`
+* data checking and test helpers in a `helpers.py`
 * prefix test files with `test_`
 * tests to have pytest markers for any services they depend on for data
 * HTTP clients should be read only and use read only credentials
@@ -166,21 +167,22 @@ pytest-services
 ├── <third party service A>
 │   ├── client.py
 │   ├── <subservice A (optional)>
+│   │   ├── __init__.py
+│   │   ├── helpers.py
 │   │   ├── resources.py
 │   │   ├── ...
 │   │   └── test_ec2_security_group_all_ports.py
-│   └── <subservice B (optional)>
-│       ├── __init__.py
-│       ├── resources.py
-│       ├── ...
-│       └── test_s3_bucket_web_hosting_disabled.py
-├── <third party service B>
+│   ├── <subservice b (optional)>
+│   │   ├── __init__.py
+│   │   ├── resources.py
+│   │   ├── ...
+│   │   └─ test_s3_bucket_web_hosting_disabled.py
+└── <third party service B>
+    ├── __init__.py
+    ├── helpers.py
     ├── resources.py
     └── test_user_has_escalation_policy.py
 ```
-
-This is just a convention and any layout where tests can import
-resources for parametrization should work.
 
 ### Adding an example test
 

--- a/aws/rds/helpers.py
+++ b/aws/rds/helpers.py
@@ -1,0 +1,109 @@
+
+
+def is_rds_db_snapshot_attr_public_access(rds_db_snapshot_attribute):
+    """
+    Checks whether a RDS snapshot attribute is:
+
+    {
+        "AttributeName": "restore",
+        "AttributeValues": ["random_aws_account_id", "any"]
+    }
+
+    >>> is_rds_db_snapshot_attr_public_access({"AttributeName": "restore", "AttributeValues": ["any"]})
+    True
+    >>> is_rds_db_snapshot_attr_public_access({"AttributeName": "restore", "AttributeValues": ["aws_account_id"]})
+    False
+    >>> is_rds_db_snapshot_attr_public_access({"AttributeName": "restore", "AttributeValues": []})
+    False
+    >>> is_rds_db_snapshot_attr_public_access({"AttributeName": "blorg", "AttributeValues": ["any"]})
+    False
+    >>> is_rds_db_snapshot_attr_public_access([])
+    Traceback (most recent call last):
+    ...
+    TypeError: list indices must be integers or slices, not str
+    >>> is_rds_db_snapshot_attr_public_access(0)
+    Traceback (most recent call last):
+    ...
+    TypeError: 'int' object is not subscriptable
+    >>> is_rds_db_snapshot_attr_public_access(None)
+    Traceback (most recent call last):
+    ...
+    TypeError: 'NoneType' object is not subscriptable
+    """
+    return rds_db_snapshot_attribute['AttributeName'] == 'restore' \
+      and 'any' in rds_db_snapshot_attribute['AttributeValues']
+
+
+def does_rds_db_security_group_grant_public_access(sg):
+    """
+    Checks an RDS instance for a DB security group with CIDRIP 0.0.0.0/0
+
+    >>> does_rds_db_security_group_grant_public_access({"IPRanges": [{"CIDRIP": "127.0.0.1/32", "Status": "authorized"}, {"CIDRIP": "0.0.0.0/0", "Status": "authorized"}]})
+    True
+    >>> does_rds_db_security_group_grant_public_access({"IPRanges": []})
+    False
+    """
+    return any(ipr['CIDRIP'] == '0.0.0.0/0' and ipr['Status'] == 'authorized' for ipr in sg['IPRanges'])
+
+
+def does_vpc_security_group_grant_public_access(sg):
+    """
+    Checks an RDS instance for a VPC security groups with ingress permission ipv4 range 0.0.0.0/0 or ipv6 range :::/0
+
+    >>> does_vpc_security_group_grant_public_access({'IpPermissions': [{'Ipv6Ranges': [], 'IpRanges': [{'CidrIp': '0.0.0.0/0'}]}]})
+    True
+    >>> does_vpc_security_group_grant_public_access({'IpPermissions': [{'Ipv6Ranges': [], 'IpRanges': []}]})
+    False
+    >>> does_vpc_security_group_grant_public_access({'IpPermissions': [{'Ipv6Ranges': [], 'IpRanges': [{'CidrIp': '192.168.1.0/0'}]}]})
+    False
+    """
+    return any(ipr['CidrIp'] == '::/0' for ipp in sg['IpPermissions'] for ipr in ipp['Ipv6Ranges']) or \
+      any(ipr['CidrIp'] == '0.0.0.0/0' for ipp in sg['IpPermissions'] for ipr in ipp['IpRanges'])
+
+
+def is_rds_db_instance_encrypted(rds_db_instance):
+    """
+    Checks the RDS instance 'StorageEncrypted' value.
+
+    >>> is_rds_db_instance_encrypted({'StorageEncrypted': True})
+    True
+    >>> is_rds_db_instance_encrypted({'StorageEncrypted': False})
+    False
+    >>> is_rds_db_instance_encrypted({})
+    Traceback (most recent call last):
+    ...
+    KeyError: 'StorageEncrypted'
+    >>> is_rds_db_instance_encrypted(0)
+    Traceback (most recent call last):
+    ...
+    TypeError: 'int' object is not subscriptable
+    >>> is_rds_db_instance_encrypted(None)
+    Traceback (most recent call last):
+    ...
+    TypeError: 'NoneType' object is not subscriptable
+    """
+    return bool(rds_db_instance['StorageEncrypted'])
+
+
+def is_rds_db_snapshot_encrypted(rds_db_snapshot):
+    """
+    Checks the RDS snapshot 'Encrypted' value.
+
+    >>> is_rds_db_snapshot_encrypted({'Encrypted': True})
+    True
+    >>> is_rds_db_snapshot_encrypted({'Encrypted': False})
+    False
+    >>> is_rds_db_snapshot_encrypted({})
+    Traceback (most recent call last):
+    ...
+    KeyError: 'Encrypted'
+    >>> is_rds_db_snapshot_encrypted(0)
+    Traceback (most recent call last):
+    ...
+    TypeError: 'int' object is not subscriptable
+    >>> is_rds_db_snapshot_encrypted(None)
+    Traceback (most recent call last):
+    ...
+    TypeError: 'NoneType' object is not subscriptable
+    """
+    return bool(rds_db_snapshot['Encrypted'])

--- a/aws/rds/test_rds_db_instance_encrypted.py
+++ b/aws/rds/test_rds_db_instance_encrypted.py
@@ -1,31 +1,8 @@
-
 import pytest
 
 from aws.rds.resources import rds_db_instances
-
-
-def is_rds_db_instance_encrypted(rds_db_instance):
-    """
-    Checks the RDS instance 'StorageEncrypted' value.
-
-    >>> is_rds_db_instance_encrypted({'StorageEncrypted': True})
-    True
-    >>> is_rds_db_instance_encrypted({'StorageEncrypted': False})
-    False
-    >>> is_rds_db_instance_encrypted({})
-    Traceback (most recent call last):
-    ...
-    KeyError: 'StorageEncrypted'
-    >>> is_rds_db_instance_encrypted(0)
-    Traceback (most recent call last):
-    ...
-    TypeError: 'int' object is not subscriptable
-    >>> is_rds_db_instance_encrypted(None)
-    Traceback (most recent call last):
-    ...
-    TypeError: 'NoneType' object is not subscriptable
-    """
-    return bool(rds_db_instance['StorageEncrypted'])
+from aws.rds.helpers import \
+    is_rds_db_instance_encrypted
 
 
 @pytest.mark.rds

--- a/aws/rds/test_rds_db_instance_not_publicly_accessible_by_vpc_sg.py
+++ b/aws/rds/test_rds_db_instance_not_publicly_accessible_by_vpc_sg.py
@@ -1,25 +1,11 @@
-
 import pytest
 
 from aws.rds.resources import (
     rds_db_instances,
     rds_db_instances_vpc_security_groups,
 )
-
-
-def does_vpc_security_group_grant_public_access(sg):
-    """
-    Checks an RDS instance for a VPC security groups with ingress permission ipv4 range 0.0.0.0/0 or ipv6 range :::/0
-
-    >>> does_vpc_security_group_grant_public_access({"IpPermissions":
-[{"CIDRIP": "127.0.0.1/32", "Status": "authorized"}, {"CIDRIP": "0.0.0.0/0", "Status": "authorized"}]})
-    True
-    >>> does_vpc_security_group_grant_public_access({"IpPermissions":
-IPRanges": []})
-    False
-    """
-    return any(ipr['CidrIp'] == '::/0' for ipp in sg['IpPermissions'] for ipr in ipp['Ipv6Ranges']) or \
-      any(ipr['CidrIp'] == '0.0.0.0/0' for ipp in sg['IpPermissions'] for ipr in ipp['IpRanges'])
+from aws.rds.helpers import \
+    does_vpc_security_group_grant_public_access
 
 
 @pytest.mark.rds

--- a/aws/rds/test_rds_db_security_group_does_not_grant_public_access.py
+++ b/aws/rds/test_rds_db_security_group_does_not_grant_public_access.py
@@ -1,20 +1,8 @@
-
-
 import pytest
 
 from aws.rds.resources import rds_db_security_groups
-
-
-def does_rds_db_security_group_grant_public_access(sg):
-    """
-    Checks an RDS instance for a DB security group with CIDRIP 0.0.0.0/0
-
-    >>> does_rds_db_security_group_grant_public_access({"IPRanges": [{"CIDRIP": "127.0.0.1/32", "Status": "authorized"}, {"CIDRIP": "0.0.0.0/0", "Status": "authorized"}]})
-    True
-    >>> does_rds_db_security_group_grant_public_access({"IPRanges": []})
-    False
-    """
-    return any(ipr['CIDRIP'] == '0.0.0.0/0' and ipr['Status'] == 'authorized' for ipr in sg['IPRanges'])
+from aws.rds.helpers import \
+    does_rds_db_security_group_grant_public_access
 
 
 @pytest.mark.rds

--- a/aws/rds/test_rds_db_snapshot_encrypted.py
+++ b/aws/rds/test_rds_db_snapshot_encrypted.py
@@ -1,31 +1,7 @@
-
 import pytest
 
 from aws.rds.resources import rds_db_snapshots
-
-
-def is_rds_db_snapshot_encrypted(rds_db_snapshot):
-    """
-    Checks the RDS snapshot 'Encrypted' value.
-
-    >>> is_rds_db_snapshot_encrypted({'Encrypted': True})
-    True
-    >>> is_rds_db_snapshot_encrypted({'Encrypted': False})
-    False
-    >>> is_rds_db_snapshot_encrypted({})
-    Traceback (most recent call last):
-    ...
-    KeyError: 'Encrypted'
-    >>> is_rds_db_snapshot_encrypted(0)
-    Traceback (most recent call last):
-    ...
-    TypeError: 'int' object is not subscriptable
-    >>> is_rds_db_snapshot_encrypted(None)
-    Traceback (most recent call last):
-    ...
-    TypeError: 'NoneType' object is not subscriptable
-    """
-    return bool(rds_db_snapshot['Encrypted'])
+from aws.rds.helpers import is_rds_db_snapshot_encrypted
 
 
 @pytest.mark.rds

--- a/aws/rds/test_rds_db_snapshot_not_publicly_accessible.py
+++ b/aws/rds/test_rds_db_snapshot_not_publicly_accessible.py
@@ -1,44 +1,11 @@
-
 import pytest
 
 from aws.rds.resources import (
     rds_db_snapshots,
     rds_db_snapshots_attributes,
 )
-
-
-def is_rds_db_snapshot_attr_public_access(rds_db_snapshot_attribute):
-    """
-    Checks whether a RDS snapshot attribute is:
-
-    {
-        "AttributeName": "restore",
-        "AttributeValues": ["random_aws_account_id", "any"]
-    }
-
-    >>> is_rds_db_snapshot_attr_public_access({"AttributeName": "restore", "AttributeValues": ["any"]})
-    True
-    >>> is_rds_db_snapshot_attr_public_access({"AttributeName": "restore", "AttributeValues": ["aws_account_id"]})
-    False
-    >>> is_rds_db_snapshot_attr_public_access({"AttributeName": "restore", "AttributeValues": []})
-    False
-    >>> is_rds_db_snapshot_attr_public_access({"AttributeName": "blorg", "AttributeValues": ["any"]})
-    False
-    >>> is_rds_db_snapshot_attr_public_access([])
-    Traceback (most recent call last):
-    ...
-    TypeError: list indices must be integers or slices, not str
-    >>> is_rds_db_snapshot_attr_public_access(0)
-    Traceback (most recent call last):
-    ...
-    TypeError: 'int' object is not subscriptable
-    >>> is_rds_db_snapshot_attr_public_access(None)
-    Traceback (most recent call last):
-    ...
-    TypeError: 'NoneType' object is not subscriptable
-    """
-    return rds_db_snapshot_attribute['AttributeName'] == 'restore' \
-      and 'any' in rds_db_snapshot_attribute['AttributeValues']
+from aws.rds.helpers import \
+    is_rds_db_snapshot_attr_public_access
 
 
 @pytest.mark.rds


### PR DESCRIPTION
Prep work for #13 

Moving them all to `helpers.py` was to not have to deal with doctest executing pytest decorators. Would get errors around `botocore_client` being a `None type` due to not having pytest set it up. Don't really want those decorators executing anyways.