### PR TITLE
aws: Add ec2 instance required tag name test

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ and options pytest-services adds for the AWS client:
 * `--aws-debug-calls` for printing (with `-s`) API calls we make
 * `--aws-profiles` for selecting one or more AWS profiles to fetch resources for or the AWS default profile / `AWS_PROFILE` environment variable
 * `--aws-regions` for selecting one or more AWS regions to fetch resources from or the default of all regions
+* `--aws-require-tag` for the `aws.ec2.test_ec2_instance_has_required_tags` test adds a Tag Name to check on all EC2 instances
 
 and produces output like the following showing a DB instance with backups disabled:
 

--- a/aws/ec2/helpers.py
+++ b/aws/ec2/helpers.py
@@ -181,6 +181,11 @@ def ec2_security_group_opens_all_ports_to_all(ec2_security_group):
     return False
 
 
+def ec2_instance_test_id(ec2_instance):
+    """A getter fn for test ids for EC2 instances"""
+    return '{0[InstanceId]}'.format(ec2_instance)
+
+
 def ec2_security_group_test_id(ec2_security_group):
     """A getter fn for test ids for EC2 security groups"""
     return '{0[GroupId]} {0[GroupName]}'.format(ec2_security_group)

--- a/aws/ec2/resources.py
+++ b/aws/ec2/resources.py
@@ -3,6 +3,18 @@
 from conftest import botocore_client
 
 
+def ec2_instances():
+    "http://botocore.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.describe_instances"
+    # Note: extracting Reservations.Instances drops EC2-Classic Groups at Reservations.Groups
+    return botocore_client\
+      .get('ec2', 'describe_instances', [], {})\
+      .extract_key('Reservations')\
+      .flatten()\
+      .extract_key('Instances')\
+      .flatten()\
+      .values()
+
+
 def ec2_security_groups():
     "http://botocore.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.describe_security_groups"
     return botocore_client\

--- a/aws/ec2/test_ec2_instance_has_required_tags.py
+++ b/aws/ec2/test_ec2_instance_has_required_tags.py
@@ -19,8 +19,18 @@ def test_ec2_instance_has_required_tags(ec2_instance, required_tag_names):
     Checks that all EC2 instances have the tags with the required names.
 
     Does not not check tag values.
+
+    >>> test_ec2_instance_has_required_tags({'Tags': [{'Key': 'Name'}]}, frozenset(['Name']))
+
+    >>> test_ec2_instance_has_required_tags({
+    ... 'InstanceId': 'iid', 'Tags': [{'Key': 'Bar'}]}, frozenset(['Name']))
+    Traceback (most recent call last):
+    ...
+    AssertionError: EC2 Instance iid missing required tags frozenset({'Name'})
+    assert not frozenset({'Name'})
     """
-    instance_tag_names = set(tag['Key'] for tag in ec2_instance['Tags'])
+    tags = ec2_instance.get('Tags', [])
+    instance_tag_names = set(tag['Key'] for tag in tags if 'Key' in tag)
 
     # set difference to find required tags not on instance
     missing_tag_names = required_tag_names - instance_tag_names

--- a/aws/ec2/test_ec2_instance_has_required_tags.py
+++ b/aws/ec2/test_ec2_instance_has_required_tags.py
@@ -6,7 +6,7 @@ from aws.ec2.resources import ec2_instances
 
 @pytest.fixture
 def required_tag_names(pytestconfig):
-    return frozenset(pytestconfig.getoption('--aws-require-tag'))
+    return frozenset(pytestconfig.getoption('--aws-require-tags'))
 
 
 @pytest.mark.ec2

--- a/aws/ec2/test_ec2_instance_has_required_tags.py
+++ b/aws/ec2/test_ec2_instance_has_required_tags.py
@@ -1,0 +1,28 @@
+import pytest
+
+from aws.ec2.helpers import ec2_instance_test_id
+from aws.ec2.resources import ec2_instances
+
+
+@pytest.fixture
+def required_tag_names(pytestconfig):
+    return frozenset(pytestconfig.getoption('--aws-require-tag'))
+
+
+@pytest.mark.ec2
+@pytest.mark.parametrize(
+    'ec2_instance',
+    ec2_instances(),
+    ids=ec2_instance_test_id)
+def test_ec2_instance_has_required_tags(ec2_instance, required_tag_names):
+    """
+    Checks that all EC2 instances have the tags with the required names.
+
+    Does not not check tag values.
+    """
+    instance_tag_names = set(tag['Key'] for tag in ec2_instance['Tags'])
+
+    # set difference to find required tags not on instance
+    missing_tag_names = required_tag_names - instance_tag_names
+    assert not missing_tag_names, \
+      "EC2 Instance {0[InstanceId]} missing required tags {1!r}".format(ec2_instance, missing_tag_names)

--- a/conftest.py
+++ b/conftest.py
@@ -30,7 +30,7 @@ def pytest_addoption(parser):
                      action='store_true',
                      help='Log whether AWS API calls hit the cache. Requires -s')
 
-    parser.addoption('--aws-require-tag',
+    parser.addoption('--aws-require-tags',
                      action='append',
                      default=[],
                      help='EC2 instance tags for the aws.ec2.test_ec2_instance_has_required_tags test to check.')

--- a/conftest.py
+++ b/conftest.py
@@ -3,6 +3,7 @@
 import botocore
 import pytest
 
+from _pytest.doctest import DoctestItem
 from _pytest.mark import MarkInfo, MarkDecorator
 from cache import patch_cache_set
 from aws.client import BotocoreClient
@@ -116,7 +117,7 @@ def pytest_runtest_makereport(item, call):
 
 
     # only add this during call instead of during any stage
-    if report.when == 'call':
+    if report.when == 'call' and not isinstance(item, DoctestItem):
         metadata = get_metadata_from_funcargs(item.funcargs)
         markers = {k: serialize_marker(v) for (k, v) in get_node_markers(item).items()}
         outcome, reason = get_outcome_and_reason(report, markers, call)

--- a/conftest.py
+++ b/conftest.py
@@ -30,6 +30,11 @@ def pytest_addoption(parser):
                      action='store_true',
                      help='Log whether AWS API calls hit the cache. Requires -s')
 
+    parser.addoption('--aws-require-tag',
+                     action='append',
+                     default=[],
+                     help='EC2 instance tags for the aws.ec2.test_ec2_instance_has_required_tags test to check.')
+
 
 def pytest_configure(config):
     global botocore_client


### PR DESCRIPTION
refs: https://github.com/mozilla-services/foxsec/issues/381

Adds a test for required EC2 instance tags.

example usage and output:

```console
pytest --ignore pagerduty/ --ignore aws/s3 --ignore aws/rds --ignore aws/iam -s --aws-profiles cloudservices-aws-stage --aws-regions us-east-1 --aws-debug-calls --aws-require-tag Name --aws-require-tag Type --aws-require-tag App --aws-require-tag Stack -k test_ec2_instance_has_required_tags
...
_____________________________________________ test_ec2_instance_has_required_tags[i-0e537fff] ______________________________________________

ec2_instance = {'AmiLaunchIndex': 0, 'Architecture': 'x86_64', 'BlockDeviceMappings': [{'DeviceName': '/dev/sda1', 'Ebs': {'AttachTim...11:53+00:00', 'DeleteOnTermination': True, 'Status': 'attached', 'VolumeId': 'vol-11d6ffff'}}], 'ClientToken': '', ...}
required_tag_names = frozenset({'App', 'Name', 'Stack', 'Type'})

    @pytest.mark.ec2
    @pytest.mark.parametrize(
        'ec2_instance',
        ec2_instances(),
        ids=ec2_instance_test_id)
    def test_ec2_instance_has_required_tags(ec2_instance, required_tag_names):
        """
        Checks that all EC2 instances have the tags with the required names.
    
        Does not not check tag values.
        """
        instance_tag_names = set(tag['Key'] for tag in ec2_instance['Tags'])
    
        # set difference to find required tags not on instance
        missing_tag_names = required_tag_names - instance_tag_names
>       assert not missing_tag_names, \
          "EC2 Instance {0[InstanceId]} missing required tags {1!r}".format(ec2_instance, missing_tag_names)
E       AssertionError: EC2 Instance i-0e537fff missing required tags frozenset({'Stack'})
E       assert not frozenset({'Stack'})

aws/ec2/test_ec2_instance_has_required_tags.py:27: AssertionError
```

r? @ajvb 