### PR TITLE
make: remove the venv as part of clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ doctest:
 	for f in $$(find . -name '*.py' | grep -vP '(venv|test|resources|init)'); do venv/bin/python -m doctest $$f; done
 
 clean: clean-cache
+	rm -rf venv
 
 clean-cache:
 	venv/bin/pytest --cache-clear --aws-profiles $(AWS_PROFILE)


### PR DESCRIPTION
This was just something I had stashed, but I think it's OK to land.

r? @ajvb 