### PR TITLE
fix error for no severity conf arg

### DIFF
--- a/severity.py
+++ b/severity.py
@@ -72,6 +72,9 @@ def parse_conf_file(conf_fd):
     # dict of test name to severity level
     rules = {}
 
+    if not conf_fd:
+        return rules
+
     for line_number, line in enumerate(conf_fd):
         if line.startswith('#'):
             continue


### PR DESCRIPTION
Fix the error:

```
INTERNALERROR>   File "/Users/gguthe/mozilla-services/pytest-services/severity.py", line 75, in parse_conf_file
INTERNALERROR>     for line_number, line in enumerate(conf_fd):
INTERNALERROR> TypeError: 'NoneType' object is not iterable
```

r? @ajvb 