### PR TITLE
use nargs for multi value args

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ And results in a severity and severity marker being included in the
 json metadata:
 
 ```console
-pytest --ignore pagerduty/ --ignore aws/s3 --ignore aws/rds --ignore aws/iam -s --aws-profiles stage --aws-regions us-east-1 --aws-require-tags Name,Type,App,Stack -k test_ec2_instance_has_required_tags --severity-config severity.conf --json=report.json
+pytest --ignore pagerduty/ --ignore aws/s3 --ignore aws/rds --ignore aws/iam -s --aws-profiles stage --aws-regions us-east-1 --aws-require-tags Name Type App Stack -k test_ec2_instance_has_required_tags --severity-config severity.conf --json=report.json
 ...
 ```
 

--- a/aws/ec2/test_ec2_instance_has_required_tags.py
+++ b/aws/ec2/test_ec2_instance_has_required_tags.py
@@ -6,7 +6,7 @@ from conftest import parse_opt
 
 @pytest.fixture
 def required_tag_names(pytestconfig):
-    return frozenset(parse_opt(pytestconfig.getoption('--aws-require-tags')))
+    return frozenset(pytestconfig.getoption('--aws-require-tags'))
 
 
 @pytest.mark.ec2

--- a/conftest.py
+++ b/conftest.py
@@ -17,13 +17,11 @@ botocore_client = None
 
 def pytest_addoption(parser):
     parser.addoption('--aws-profiles',
-                     action='append',
-                     default=[],
+                     nargs='*',
                      help='Set default AWS profiles to use. Defaults to the current AWS profile i.e. [None].')
 
     parser.addoption('--aws-regions',
-                     action='append',
-                     default=[],
+                     nargs='*',
                      help='Set default AWS regions to use. Defaults to all available ec2 regions')
 
     parser.addoption('--aws-debug-calls',
@@ -35,8 +33,7 @@ def pytest_addoption(parser):
                      help='Log whether AWS API calls hit the cache. Requires -s')
 
     parser.addoption('--aws-require-tags',
-                     action='append',
-                     default=[],
+                     nargs='*',
                      help='EC2 instance tags for the aws.ec2.test_ec2_instance_has_required_tags test to check.')
 
     parser.addoption('--severity-config',
@@ -47,9 +44,6 @@ def pytest_addoption(parser):
 def parse_opt(opt):
     if not len(opt):
         return None
-
-    if ',' in opt[0]:
-        return opt[0].split(',')
 
     return opt
 


### PR DESCRIPTION
refs https://github.com/mozilla-services/pytest-services/issues/31

I think this is slightly more ergonomic.

r? @ajvb 