### PR TITLE
Moved test_ec2_instance_has_required_tags logic to a helper

### DIFF
--- a/aws/ec2/helpers.py
+++ b/aws/ec2/helpers.py
@@ -145,7 +145,7 @@ def ec2_security_group_opens_all_ports_to_self(ec2_security_group):
 
     for ipp in ec2_security_group['IpPermissions']:
         if ip_permission_opens_all_ports(ipp) and \
-              ip_permission_grants_access_to_group_with_id(ipp, self_group_id):
+                ip_permission_grants_access_to_group_with_id(ipp, self_group_id):
             return True
 
     return False
@@ -214,3 +214,18 @@ def is_ebs_volume_encrypted(ebs):
     TypeError: 'NoneType' object is not subscriptable
     """
     return ebs['Encrypted']
+
+
+def ec2_instance_missing_tag_names(ec2_instance, required_tag_names):
+    """
+    Returns any tag names that are missing from an EC2 Instance.
+
+    >>> ec2_instance_missing_tag_names({'Tags': [{'Key': 'Name'}]}, frozenset(['Name']))
+    frozenset()
+    >>> ec2_instance_missing_tag_names({
+    ... 'InstanceId': 'iid', 'Tags': [{'Key': 'Bar'}]}, frozenset(['Name']))
+    frozenset({'Name'})
+    """
+    tags = ec2_instance.get('Tags', [])
+    instance_tag_names = set(tag['Key'] for tag in tags if 'Key' in tag)
+    return required_tag_names - instance_tag_names

--- a/aws/ec2/test_ec2_instance_has_required_tags.py
+++ b/aws/ec2/test_ec2_instance_has_required_tags.py
@@ -1,6 +1,9 @@
 import pytest
 
-from aws.ec2.helpers import ec2_instance_test_id
+from aws.ec2.helpers import (
+    ec2_instance_test_id,
+    ec2_instance_missing_tag_names
+)
 from aws.ec2.resources import ec2_instances
 
 
@@ -18,21 +21,8 @@ def test_ec2_instance_has_required_tags(ec2_instance, required_tag_names):
     """
     Checks that all EC2 instances have the tags with the required names.
 
-    Does not not check tag values.
-
-    >>> test_ec2_instance_has_required_tags({'Tags': [{'Key': 'Name'}]}, frozenset(['Name']))
-
-    >>> test_ec2_instance_has_required_tags({
-    ... 'InstanceId': 'iid', 'Tags': [{'Key': 'Bar'}]}, frozenset(['Name']))
-    Traceback (most recent call last):
-    ...
-    AssertionError: EC2 Instance iid missing required tags frozenset({'Name'})
-    assert not frozenset({'Name'})
+    Does not check tag values.
     """
-    tags = ec2_instance.get('Tags', [])
-    instance_tag_names = set(tag['Key'] for tag in tags if 'Key' in tag)
-
-    # set difference to find required tags not on instance
-    missing_tag_names = required_tag_names - instance_tag_names
-    assert not missing_tag_names, "EC2 Instance {0[InstanceId]} missing required tags {1!r}".format(
-          ec2_instance, missing_tag_names)
+    missing_tag_names = ec2_instance_missing_tag_names(ec2_instance, required_tag_names)
+    assert not missing_tag_names, \
+        "EC2 Instance {0[InstanceId]} missing required tags {1!r}".format(ec2_instance, missing_tag_names)


### PR DESCRIPTION
1. This allows for the current doctest setup to work.
2. With the merging of https://github.com/mozilla-services/pytest-services/pull/43, we are now using test's docstrings for the description.

r? @g-k 