### PR TITLE
Small fixes for pytest_wrapper.sh/make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ flake8: check_venv
 	flake8 --max-line-length 120 $(shell find . -name '*.py' -not -path "./venv/*")
 
 install: venv
-	( . venv/bin/activate; pip install -r requirements.txt )
+	( . venv/bin/activate && pip install -r requirements.txt )
 
 venv:
 	python3 -m venv venv

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ flake8: check_venv
 	flake8 --max-line-length 120 $(shell find . -name '*.py' -not -path "./venv/*")
 
 install: venv
-	pip install -r requirements.txt
+	( . venv/bin/activate; pip install -r requirements.txt )
 
 venv:
 	python3 -m venv venv

--- a/pytest_wrapper.sh
+++ b/pytest_wrapper.sh
@@ -10,6 +10,7 @@ set -e
 # Docker should mount an ~/.aws/credentials file
 
 make install
+. venv/bin/activate
 
 # allow pytest commands to fail so we can report results
 set +e


### PR DESCRIPTION
* `make install` now sources venv before pip installing
* Have pytest_wrapper.sh source the venv itself

r? @g-k 