### PR TITLE
Few changes based on initial CI run

### DIFF
--- a/aws/client.py
+++ b/aws/client.py
@@ -231,7 +231,7 @@ class BotocoreClient:
                     for item in keyed_result:
                         # Added for IAM inline policies call, as it
                         # returns a list of strings.
-                        if not isinstance(item, str):
+                        if isinstance(item, dict):
                             item['__pytest_meta'] = result['__pytest_meta']
                 elif isinstance(keyed_result, dict):
                     keyed_result['__pytest_meta'] = result['__pytest_meta']

--- a/aws/ec2/test_ec2_instance_has_required_tags.py
+++ b/aws/ec2/test_ec2_instance_has_required_tags.py
@@ -23,6 +23,8 @@ def test_ec2_instance_has_required_tags(ec2_instance, required_tag_names):
 
     Does not check tag values.
     """
+    if len(required_tag_names) == 0:
+        pytest.skip()  # reason='No required tag names were provided'
     missing_tag_names = ec2_instance_missing_tag_names(ec2_instance, required_tag_names)
     assert not missing_tag_names, \
         "EC2 Instance {0[InstanceId]} missing required tags {1!r}".format(ec2_instance, missing_tag_names)

--- a/conftest.py
+++ b/conftest.py
@@ -34,6 +34,7 @@ def pytest_addoption(parser):
 
     parser.addoption('--aws-require-tags',
                      nargs='*',
+                     default=[],
                      help='EC2 instance tags for the aws.ec2.test_ec2_instance_has_required_tags test to check.')
 
     parser.addoption('--offline',

--- a/service_report_generator.py
+++ b/service_report_generator.py
@@ -205,9 +205,9 @@ def parse_args():
 def get_test_status(outcome):
     if outcome == 'errored':
         return 'err'
-    elif outcome in ['xfailed', 'xpassed', 'skipped']:
+    elif outcome in ['xfailed', 'xpassed']:
         return 'warn'
-    elif outcome == 'passed':
+    elif outcome in ['passed', 'skipped']:
         return 'pass'
     elif outcome == 'failed':
         return 'fail'


### PR DESCRIPTION
* Skip test_ec2_instance_has_required_tags if
  no tags were passed in.
* Provide a default of [] to --aws-require-tags
  (else it errors)
* Move skipped from being a warn to being a pass.
* Improve type checking of item in extract_key

r? @g-k 