### PR TITLE
fix reason in pytest.skip() calls

### DIFF
--- a/aws/ec2/test_ec2_instance_has_required_tags.py
+++ b/aws/ec2/test_ec2_instance_has_required_tags.py
@@ -24,7 +24,7 @@ def test_ec2_instance_has_required_tags(ec2_instance, required_tag_names):
     Does not check tag values.
     """
     if len(required_tag_names) == 0:
-        pytest.skip()  # reason='No required tag names were provided'
+        pytest.skip('No required tag names were provided')
     missing_tag_names = ec2_instance_missing_tag_names(ec2_instance, required_tag_names)
     assert not missing_tag_names, \
         "EC2 Instance {0[InstanceId]} missing required tags {1!r}".format(ec2_instance, missing_tag_names)

--- a/aws/rds/test_rds_db_instance_is_postgres_with_invalid_certificate.py
+++ b/aws/rds/test_rds_db_instance_is_postgres_with_invalid_certificate.py
@@ -14,10 +14,10 @@ from aws.rds.resources import rds_db_instances_with_tags
                          ids=lambda db_instance: db_instance['DBInstanceIdentifier'])
 def test_rds_db_instance_is_postgres_with_invalid_certificate(rds_db_instance):
     if rds_db_instance['Engine'] != 'postgres':
-        pytest.skip()  # reason='RDS DB instance engine is not Postgres.'
+        pytest.skip('RDS DB instance engine is not Postgres.')
 
     if rds_db_instance['DBInstanceStatus'] == 'creating':
-        pytest.skip()  # reason='RDS DB instance status is still "creating".'
+        pytest.skip('RDS DB instance status is still "creating".')
 
     ict = rds_db_instance['InstanceCreateTime']
     if isinstance(ict, str):

--- a/aws/rds/test_rds_db_instance_minor_version_updates_enabled.py
+++ b/aws/rds/test_rds_db_instance_minor_version_updates_enabled.py
@@ -18,7 +18,7 @@ def test_rds_db_instance_minor_version_updates_enabled(rds_db_instance):
     http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Upgrading.html
     """
     if rds_db_instance['Engine'] not in ['mariadb', 'mysql', 'postgres']:
-        pytest.skip(reason='Engine type %s does not support minor version updates.' % rds_db_instance['Engine'])
+        pytest.skip('Engine type %s does not support minor version updates.' % rds_db_instance['Engine'])
 
     assert rds_db_instance['AutoMinorVersionUpgrade'], \
         'Minor version automatic upgrades disabled for {}'.format(rds_db_instance['DBInstanceIdentifier'])

--- a/aws/s3/test_s3_bucket_does_not_grant_all_principals_all_actions.py
+++ b/aws/s3/test_s3_bucket_does_not_grant_all_principals_all_actions.py
@@ -38,7 +38,7 @@ def test_s3_bucket_does_not_grant_all_principals_all_actions(
     * add conditions http://docs.aws.amazon.com/AmazonS3/latest/dev/amazon-s3-policy-keys.html
     """
     if not s3_bucket_policy:
-        pytest.skip()  # reason='Bucket has no policy.' which defaults to private
+        pytest.skip('Bucket has no policy, which means it defaults to private.')
         # https://docs.aws.amazon.com/config/latest/developerguide/s3-bucket-policy.html
 
     policy = json.loads(s3_bucket_policy)

--- a/aws/s3/test_s3_bucket_no_world_acl.py
+++ b/aws/s3/test_s3_bucket_no_world_acl.py
@@ -31,7 +31,7 @@ def test_s3_bucket_no_world_acl(s3_bucket,
     for grant in s3_bucket_acl['Grants']:
         grantee = grant['Grantee']
         if 'URI' not in grantee:
-            pytest.skip()  # reason='S3 Bucket ACL does not use URI.'
+            pytest.skip('S3 Bucket ACL does not use URI.')
 
         grantee_uri = grantee['URI']
         assert not any(grantee_uri.startswith(group) for group in AWS_PREDEFINED_GROUPS)


### PR DESCRIPTION
not a keyed parameter when called directly

docs: https://docs.pytest.org/en/latest/skipping.html#skipping-test-functions