### PR TITLE
Provide error default for redshift secgroups

### DIFF
--- a/aws/redshift/resources.py
+++ b/aws/redshift/resources.py
@@ -6,4 +6,9 @@ from conftest import botocore_client
 def redshift_cluster_security_groups():
     "http://botocore.readthedocs.io/en/latest/reference/services/redshift.html#Redshift.Client.describe_cluster_security_groups" # NOQA
     return botocore_client.get(
-        'redshift', 'describe_cluster_security_groups', [], {}).extract_key('ClusterSecurityGroups').flatten().values()
+        'redshift',
+        'describe_cluster_security_groups',
+        [],
+        {},
+        result_from_error=lambda error, call: {'ClusterSecurityGroups': []}
+    ).extract_key('ClusterSecurityGroups').flatten().values()

--- a/aws/redshift/test_redshift_security_group_does_not_allow_all_ips_access.py
+++ b/aws/redshift/test_redshift_security_group_does_not_allow_all_ips_access.py
@@ -10,7 +10,6 @@ from aws.redshift.helpers import (
 
 
 @pytest.mark.redshift
-@pytest.mark.xskip(reason="Redshift security groups are only supported on EC2-Classic accounts")
 @pytest.mark.parametrize(
     'security_group',
     redshift_cluster_security_groups(),


### PR DESCRIPTION
Instead of skipping the redshift test by default,
if there is an error (most likely due to using EC2-VPC)
the resources call will return an empty list. Pytest will
display this as a `skip`, which is what we would want.

The main thing this provides is that it will support both
EC2-VPC and EC2-Classic without any code/config changes.

Fixes #66
r? @g-k 