### PR TITLE
test_ec2_security_group_opens_specific_ports_to_all

### DIFF
--- a/aws/ec2/helpers.py
+++ b/aws/ec2/helpers.py
@@ -238,6 +238,9 @@ def ec2_security_group_opens_specific_ports_to_all(ec2_security_group):
             continue
 
         if ip_permission_cidr_allows_all_ips(ipp):
+            if 'FromPort' not in ipp or 'ToPort' not in ipp:
+                continue
+
             from_port, to_port = ipp['FromPort'], ipp['ToPort']
             if from_port == to_port and from_port in [80, 25, 443, 465]:
                 continue

--- a/aws/ec2/test_ec2_security_group_opens_specific_ports_to_all.py
+++ b/aws/ec2/test_ec2_security_group_opens_specific_ports_to_all.py
@@ -1,0 +1,22 @@
+
+
+import pytest
+
+from aws.ec2.helpers import (
+    ec2_security_group_test_id,
+    ec2_security_group_opens_specific_ports_to_all,
+)
+from aws.ec2.resources import (
+    ec2_security_groups,
+)
+
+
+@pytest.mark.ec2
+@pytest.mark.parametrize('ec2_security_group',
+                         ec2_security_groups(),
+                         ids=ec2_security_group_test_id)
+def test_ec2_security_group_opens_specific_ports_to_all(ec2_security_group):
+    """Checks whether an EC2 security group includes a permission allowing
+    inbound access on specific ports. Excluded ports are 80, 25, 443, and 465.
+    """
+    assert not ec2_security_group_opens_specific_ports_to_all(ec2_security_group)


### PR DESCRIPTION
Includes a test that mimics Trusted Advisor's "Specific Ports
Unrestricted" test, which checks if any security group has
any ports beside 80, 25, 443, or 465 exposed to the public
internet.

Fixes #76 

r? @g-k 