### PR TITLE
Remove port 25 and 465 from specific port test

### DIFF
--- a/aws/ec2/helpers.py
+++ b/aws/ec2/helpers.py
@@ -242,7 +242,7 @@ def ec2_security_group_opens_specific_ports_to_all(ec2_security_group):
                 continue
 
             from_port, to_port = ipp['FromPort'], ipp['ToPort']
-            if from_port == to_port and from_port in [80, 25, 443, 465]:
+            if from_port == to_port and from_port in [80, 443]:
                 continue
 
             return True

--- a/aws/ec2/test_ec2_security_group_opens_specific_ports_to_all.py
+++ b/aws/ec2/test_ec2_security_group_opens_specific_ports_to_all.py
@@ -17,6 +17,6 @@ from aws.ec2.resources import (
                          ids=ec2_security_group_test_id)
 def test_ec2_security_group_opens_specific_ports_to_all(ec2_security_group):
     """Checks whether an EC2 security group includes a permission allowing
-    inbound access on specific ports. Excluded ports are 80, 25, 443, and 465.
+    inbound access on specific ports. Excluded ports are 80 and 443.
     """
     assert not ec2_security_group_opens_specific_ports_to_all(ec2_security_group)


### PR DESCRIPTION
Removes smtp ports from
test_ec2_security_group_opens_specific_ports_to_all