### PR TITLE
Only test secgroups attached to resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,16 @@ all: check_venv
 	pytest
 
 awsci: check_venv
-	pytest --continue-on-collection-errors aws/ --json=results-$(AWS_PROFILE)-$(TODAY).json $(PYTEST_OPTS)
+	pytest --continue-on-collection-errors aws/ \
+		--ignore aws/ec2/test_ec2_security_group_in_use.py \
+		--json=results-$(AWS_PROFILE)-$(TODAY).json $(PYTEST_OPTS)
 
 aws-sg: check_venv
 	pytest --continue-on-collection-errors \
-		aws/ec2/test_ec2_security_group_in_use.py \
 		aws/ec2/test_ec2_security_group_opens_all_ports.py \
 		aws/ec2/test_ec2_security_group_opens_all_ports_to_all.py \
 		aws/ec2/test_ec2_security_group_opens_all_ports_to_self.py \
+		aws/ec2/test_ec2_security_group_opens_specific_ports_to_all.py \
 		aws/rds/test_rds_db_security_group_does_not_grant_public_access.py \
 		aws/rds/test_rds_db_instance_not_publicly_accessible_by_vpc_sg.py \
 		--json=results-sg-$(AWS_PROFILE)-$(TODAY).json $(PYTEST_OPTS)

--- a/aws/ec2/test_ec2_security_group_opens_all_ports.py
+++ b/aws/ec2/test_ec2_security_group_opens_all_ports.py
@@ -7,16 +7,19 @@ from aws.ec2.helpers import (
     ec2_security_group_opens_all_ports,
 )
 from aws.ec2.resources import (
-    ec2_security_groups,
+    ec2_security_groups_with_in_use_flag,
 )
 
 
 @pytest.mark.ec2
 @pytest.mark.parametrize('ec2_security_group',
-                         ec2_security_groups(),
+                         ec2_security_groups_with_in_use_flag(),
                          ids=ec2_security_group_test_id)
 def test_ec2_security_group_opens_all_ports(ec2_security_group):
     """Checks whether an EC2 security group includes a permission
     allowing inbound access on all ports.
     """
-    assert not ec2_security_group_opens_all_ports(ec2_security_group)
+    if ec2_security_group["InUse"]:
+        assert not ec2_security_group_opens_all_ports(ec2_security_group)
+    else:
+        pytest.skip("Security group not in use")

--- a/aws/ec2/test_ec2_security_group_opens_all_ports_to_all.py
+++ b/aws/ec2/test_ec2_security_group_opens_all_ports_to_all.py
@@ -7,15 +7,18 @@ from aws.ec2.helpers import (
     ec2_security_group_opens_all_ports_to_all,
 )
 from aws.ec2.resources import (
-    ec2_security_groups,
+    ec2_security_groups_with_in_use_flag,
 )
 
 
 @pytest.mark.ec2
 @pytest.mark.parametrize('ec2_security_group',
-                         ec2_security_groups(),
+                         ec2_security_groups_with_in_use_flag(),
                          ids=ec2_security_group_test_id)
 def test_ec2_security_group_opens_all_ports_to_all(ec2_security_group):
     """Checks whether an EC2 security group includes a permission
     allowing inbound access to all IPs on all ports."""
-    assert not ec2_security_group_opens_all_ports_to_all(ec2_security_group)
+    if ec2_security_group["InUse"]:
+        assert not ec2_security_group_opens_all_ports_to_all(ec2_security_group)
+    else:
+        pytest.skip("Security group not in use")

--- a/aws/ec2/test_ec2_security_group_opens_all_ports_to_self.py
+++ b/aws/ec2/test_ec2_security_group_opens_all_ports_to_self.py
@@ -7,15 +7,18 @@ from aws.ec2.helpers import (
     ec2_security_group_opens_all_ports_to_self,
 )
 from aws.ec2.resources import (
-    ec2_security_groups,
+    ec2_security_groups_with_in_use_flag,
 )
 
 
 @pytest.mark.ec2
 @pytest.mark.parametrize('ec2_security_group',
-                         ec2_security_groups(),
+                         ec2_security_groups_with_in_use_flag(),
                          ids=ec2_security_group_test_id)
 def test_ec2_security_group_opens_all_ports_to_self(ec2_security_group):
     """Checks whether an EC2 security group includes a permission
     allowing unrestricted inbound access within the security group."""
-    assert not ec2_security_group_opens_all_ports_to_self(ec2_security_group)
+    if ec2_security_group["InUse"]:
+        assert not ec2_security_group_opens_all_ports_to_self(ec2_security_group)
+    else:
+        pytest.skip("Security group not in use")

--- a/aws/ec2/test_ec2_security_group_opens_specific_ports_to_all.py
+++ b/aws/ec2/test_ec2_security_group_opens_specific_ports_to_all.py
@@ -7,16 +7,19 @@ from aws.ec2.helpers import (
     ec2_security_group_opens_specific_ports_to_all,
 )
 from aws.ec2.resources import (
-    ec2_security_groups,
+    ec2_security_groups_with_in_use_flag,
 )
 
 
 @pytest.mark.ec2
 @pytest.mark.parametrize('ec2_security_group',
-                         ec2_security_groups(),
+                         ec2_security_groups_with_in_use_flag(),
                          ids=ec2_security_group_test_id)
 def test_ec2_security_group_opens_specific_ports_to_all(ec2_security_group):
     """Checks whether an EC2 security group includes a permission allowing
     inbound access on specific ports. Excluded ports are 80 and 443.
     """
-    assert not ec2_security_group_opens_specific_ports_to_all(ec2_security_group)
+    if ec2_security_group["InUse"]:
+        assert not ec2_security_group_opens_specific_ports_to_all(ec2_security_group)
+    else:
+        pytest.skip("Security group not in use")


### PR DESCRIPTION
This changes aws/ec2/test_ec2_security_group_opens_* tests to only fail if they
are attached to a resource. It also takes test_ec2_security_group_in_use out of
the default runs defined as make targets.

r? @g-k 

