### PR TITLE
Support csv output of service report

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -96,6 +96,7 @@ METADATA_KEYS = [
     'UserName',
     'VolumeId',
     'VpcId',
+    '__pytest_meta',
 ]
 
 


### PR DESCRIPTION
I've been using a modified version of service_report_generator.py
to generate csv's to use within spreadsheets. This includes a cleaned
up version of that code to allow for this option.

Also includes:
* adding __pytest_meta to metadata so that we can get the region of the resource.
* change to the language of 'warn' - as it's only being actively used for exemptions atm.

r? @g-k 