### PR TITLE
"Does 'Admin' user have access/secret keys" test

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ The below policy will allow you to run all AWS tests in pytest-services against 
         "elasticloadbalancing:DescribeLoadBalancers",
         "es:DescribeElasticsearchDomains",
         "es:ListDomainNames",
+        "iam:GenerateCredentialReport",
+        "iam:GetCredentialReport",
         "iam:GetLoginProfile",
         "iam:ListAttachedGroupPolicies",
         "iam:ListAttachedUserPolicies",

--- a/aws/client.py
+++ b/aws/client.py
@@ -177,7 +177,7 @@ class BotocoreClient:
             profiles=None,
             regions=None,
             result_from_error=None,
-            dont_cache=False):
+            do_not_cache=False):
 
         # TODO:
         # For services that don't have the concept of regions,
@@ -197,7 +197,7 @@ class BotocoreClient:
                 call_kwargs,
                 profiles=profiles or self.profiles,
                 regions=regions or self.regions,
-                cache=self.cache if not dont_cache else None,
+                cache=self.cache if not do_not_cache else None,
                 result_from_error=result_from_error,
                 debug_calls=self.debug_calls,
                 debug_cache=self.debug_cache))

--- a/aws/client.py
+++ b/aws/client.py
@@ -113,14 +113,17 @@ def get_aws_resource(service_name,
                                      method=method_name,
                                      args=call_args,
                                      kwargs=call_kwargs)
-        ckey = cache_key(call)
 
         if debug_calls:
             print('calling', call)
 
-        cached_result = cache.get(ckey, None)
-        if debug_cache and cached_result is not None:
-            print('found cached value for', ckey)
+        cached_result = None
+        if cache is not None:
+            ckey = cache_key(call)
+            cached_result = cache.get(ckey, None)
+
+            if debug_cache and cached_result is not None:
+                print('found cached value for', ckey)
 
         if cached_result is not None:
             result = cached_result
@@ -138,10 +141,11 @@ def get_aws_resource(service_name,
 
                     result = result_from_error(error, call)
 
-            if debug_cache:
-                print('setting cache value for', ckey)
+            if cache is not None:
+                if debug_cache:
+                    print('setting cache value for', ckey)
 
-            cache.set(ckey, result)
+                cache.set(ckey, result)
 
         yield result
 
@@ -172,7 +176,8 @@ class BotocoreClient:
             call_kwargs,
             profiles=None,
             regions=None,
-            result_from_error=None):
+            result_from_error=None,
+            dont_cache=False):
 
         # TODO:
         # For services that don't have the concept of regions,
@@ -192,7 +197,7 @@ class BotocoreClient:
                 call_kwargs,
                 profiles=profiles or self.profiles,
                 regions=regions or self.regions,
-                cache=self.cache,
+                cache=self.cache if not dont_cache else None,
                 result_from_error=result_from_error,
                 debug_calls=self.debug_calls,
                 debug_cache=self.debug_cache))

--- a/aws/iam/resources.py
+++ b/aws/iam/resources.py
@@ -155,7 +155,7 @@ def iam_mfa_devices(users):
 
 def iam_generate_credential_report():
     "http://botocore.readthedocs.io/en/latest/reference/services/iam.html#IAM.Client.generate_credential_report"
-    return botocore_client.get('iam', 'generate_credential_report', [], {}, dont_cache=True).results[0].get('State')
+    return botocore_client.get('iam', 'generate_credential_report', [], {}, do_not_cache=True).results[0].get('State')
 
 
 def iam_get_credential_report():
@@ -168,7 +168,7 @@ def iam_get_credential_report():
         time.sleep(2)
 
     # We want this to blow up if it can't get the "Content"
-    content = botocore_client.get('iam', 'get_credential_report', [], {}, dont_cache=True).results[0]['Content']
+    content = botocore_client.get('iam', 'get_credential_report', [], {}, do_not_cache=True).results[0]['Content']
     decoded_content = content.decode("utf-8")
     return list(csv.DictReader(decoded_content.split("\n")))
 

--- a/aws/iam/test_iam_admin_user_with_access_keys.py
+++ b/aws/iam/test_iam_admin_user_with_access_keys.py
@@ -1,0 +1,18 @@
+import pytest
+
+from aws.iam.resources import iam_admin_users_with_credential_report
+
+
+@pytest.mark.iam
+@pytest.mark.parametrize(
+        'iam_admin_user',
+        iam_admin_users_with_credential_report(),
+        ids=lambda login: login['UserName'])
+def test_iam_admin_user_with_access_key(iam_admin_user):
+    """Test that all "admin" users do not have access keys
+    associated to their user.
+    """
+    assert iam_admin_user['CredentialReport']['access_key_1_active'] != 'true', \
+        'Access key found for admin user: {}'.format(iam_admin_user['UserName'])
+    assert iam_admin_user['CredentialReport']['access_key_2_active'] != 'true', \
+        'Access key found for admin user: {}'.format(iam_admin_user['UserName'])

--- a/aws/iam/test_iam_admin_user_without_mfa.py
+++ b/aws/iam/test_iam_admin_user_without_mfa.py
@@ -12,6 +12,8 @@ from aws.iam.resources import (
         zip(iam_admin_login_profiles(), iam_admin_mfa_devices()),
         ids=lambda login: login['UserName'])
 def test_iam_admin_user_without_mfa(iam_login_profile, iam_user_mfa_devices):
+    """Test that all "admin" users with console access also have an MFA device.
+    """
     if bool(iam_login_profile):
         assert len(iam_user_mfa_devices) > 0, \
             'No MFA Device found for {}'.format(iam_login_profile['UserName'])

--- a/aws/iam/test_iam_user_without_mfa.py
+++ b/aws/iam/test_iam_user_without_mfa.py
@@ -12,6 +12,8 @@ from aws.iam.resources import (
         zip(iam_user_login_profiles(), iam_user_mfa_devices()),
         ids=lambda login: login['UserName'])
 def test_iam_user_without_mfa(iam_login_profile, iam_user_mfa_devices):
+    """Test that all users with console access also have an MFA device.
+    """
     if bool(iam_login_profile):
         assert len(iam_user_mfa_devices) > 0, \
             'No MFA Device found for {}'.format(iam_login_profile['UserName'])


### PR DESCRIPTION
* Adds "test_iam_admin_user_with_access_key" - A test that all "admin" users do not have access keys associated to their user.
* Adds `do_not_cache` option for `BotocoreClient.get()`

r? @g-k 

Fixes #86