### PR TITLE
Config refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ and options pytest-services adds:
 * `--aws-profiles` for selecting one or more AWS profiles to fetch resources for or the AWS default profile / `AWS_PROFILE` environment variable
 * `--aws-regions` for selecting one or more AWS regions to fetch resources from or the default of all regions
 * `--offline` a flag to tell HTTP clients to not make requests and return empty params
-* [`--config`](#test-config) path to test custom config file
+* [`--config`](#custom-test-config) path to test custom config file
 
 and produces output like the following showing a DB instance with backups disabled:
 
@@ -173,9 +173,9 @@ head .cache/v/pytest_aws:cloudservices-aws-stage:us-west-2:rds:describe_db_insta
 
 These files can be removed individually or all at once with [the pytest --cache-clear](https://docs.pytest.org/en/latest/cache.html#usage) option.
 
-## Test Config
+## Custom Test Config
 
-pytest-services adds an optional `--config` cli option for passing in a custom config file specific to tests within pytest-services.
+pytest-services adds a `--config` cli option for passing in a custom config file specific to tests within pytest-services.
 
 The example config in repo (`config.yaml.example`):
 ```
@@ -289,7 +289,7 @@ python -m json.tool report.json | grep -C 20 xfail
 
 #### Test Severity
 
-pytest-services adds the ability to mark the severity of a certain test. A severity can be `INFO`, `WARN`, or `ERROR`.
+pytest-services custom config format adds support for marking the severity of a certain test. A severity can be `INFO`, `WARN`, or `ERROR`.
 
 These do not modify pytest results (pass, fail, xfail, skip, etc.).
 
@@ -346,8 +346,8 @@ python -m json.tool report.json
 
 ### Test Regressions
 
-pytest-services adds the ability to mark specific tests on specific resources as regressions. As with `severity`, this does
-not modify the pytest results, but rather adds a marker that can be used when analyzing the results.
+pytest-services custom config format adds support for marking specific tests on specific resources as regressions.
+As with `severity` this does not modify the pytest results, but rather adds a marker that can be used when analyzing the results.
 
 The config looks like:
 ```

--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ and options pytest-services adds:
 * `--aws-debug-calls` for printing (with `-s`) API calls we make
 * `--aws-profiles` for selecting one or more AWS profiles to fetch resources for or the AWS default profile / `AWS_PROFILE` environment variable
 * `--aws-regions` for selecting one or more AWS regions to fetch resources from or the default of all regions
-* `--aws-require-tag` adds Tag names to check on all EC2 instances for the `aws.ec2.test_ec2_instance_has_required_tags` test
-* `--aws-whitelisted-ports` adds ports to the whitelist for the `aws.ec2.test_ec2_security_group_opens_specific_ports_to_all` test
 * `--offline` a flag to tell HTTP clients to not make requests and return empty params
 * [`--config`](#test-config) path to test custom config file
 
@@ -213,8 +211,6 @@ aws:
         - 22
         - 2222
 ```
-
-The `--aws-require-tag` and `--aws-whitelisted-ports` will overwrite whatever is present in the config file.
 
 #### Test Severity
 

--- a/aws/ec2/helpers.py
+++ b/aws/ec2/helpers.py
@@ -1,6 +1,3 @@
-from conftest import whitelisted_ports
-
-
 def ip_permission_opens_all_ports(ipp):
     """
     Returns True if an EC2 security group IP permission opens all
@@ -205,7 +202,7 @@ def ec2_security_group_opens_all_ports_to_all(ec2_security_group):
     return False
 
 
-def ec2_security_group_opens_specific_ports_to_all(ec2_security_group):
+def ec2_security_group_opens_specific_ports_to_all(ec2_security_group, whitelisted_ports=[]):
     """
     Returns True if an ec2 security group includes a permission
     allowing all IPs inbound access on specific unsafe ports and False

--- a/aws/ec2/helpers.py
+++ b/aws/ec2/helpers.py
@@ -202,7 +202,7 @@ def ec2_security_group_opens_all_ports_to_all(ec2_security_group):
     return False
 
 
-def ec2_security_group_opens_specific_ports_to_all(ec2_security_group, whitelisted_ports=[]):
+def ec2_security_group_opens_specific_ports_to_all(ec2_security_group, whitelisted_ports=None):
     """
     Returns True if an ec2 security group includes a permission
     allowing all IPs inbound access on specific unsafe ports and False
@@ -228,6 +228,9 @@ def ec2_security_group_opens_specific_ports_to_all(ec2_security_group, whitelist
     >>> ec2_security_group_opens_specific_ports_to_all([])
     False
     """
+    if whitelisted_ports is None:
+        whitelisted_ports = []
+
     if 'IpPermissions' not in ec2_security_group:
         return False
 

--- a/aws/ec2/test_ec2_instance_has_required_tags.py
+++ b/aws/ec2/test_ec2_instance_has_required_tags.py
@@ -9,7 +9,7 @@ from aws.ec2.resources import ec2_instances
 
 @pytest.fixture
 def required_tag_names(pytestconfig):
-    return frozenset(pytestconfig.getoption('--aws-require-tags'))
+    return frozenset(pytestconfig.custom_config.aws.required_tags)
 
 
 @pytest.mark.ec2

--- a/aws/ec2/test_ec2_security_group_opens_specific_ports_to_all.py
+++ b/aws/ec2/test_ec2_security_group_opens_specific_ports_to_all.py
@@ -1,5 +1,3 @@
-
-
 import pytest
 
 from aws.ec2.helpers import (
@@ -15,12 +13,16 @@ from aws.ec2.resources import (
 @pytest.mark.parametrize('ec2_security_group',
                          ec2_security_groups_with_in_use_flag(),
                          ids=ec2_security_group_test_id)
-def test_ec2_security_group_opens_specific_ports_to_all(ec2_security_group):
+def test_ec2_security_group_opens_specific_ports_to_all(ec2_security_group, aws_config):
     """Checks whether an EC2 security group includes a permission allowing
     inbound access on specific ports. Excluded ports are 80 and 443.
     """
     if ec2_security_group["InUse"]:
-        # Additional ports can be whitelisted with --aws-whitelisted-ports
-        assert not ec2_security_group_opens_specific_ports_to_all(ec2_security_group)
+        whitelisted_ports = aws_config.get_whitelisted_ports(
+                ec2_security_group_test_id(ec2_security_group)
+        )
+        assert not ec2_security_group_opens_specific_ports_to_all(
+            ec2_security_group, whitelisted_ports
+        )
     else:
         pytest.skip("Security group not in use")

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,0 +1,36 @@
+#
+# pytest-services config file
+#
+# Documentation on config file found in README.md
+#
+exemptions:
+  - test_name: test_ec2_instance_has_required_tags
+    test_param_id: i-0123456789f014c162
+    expiration_day: 2019-01-01
+    reason: ec2 instance has no owner
+  - test_name: test_ec2_security_group_opens_specific_ports_to_all
+    test_param_id: '*HoneyPot'
+    expiration_day: 2020-01-01
+    reason: purposefully insecure security group
+severities:
+  - test_name: test_ec2_instance_has_required_tags
+    severity: INFO
+  - test_name: '*'
+    severity: ERROR
+regressions:
+  - test_name: test_ec2_security_group_opens_all_ports_to_all
+    test_param_id: '*mycustomgroup'
+    comment: this was remediated by ops team
+aws:
+  required_tags:
+    - Name
+    - Type
+    - App
+    - Env
+  whitelisted_ports_global:
+    - 25
+  whitelisted_ports:
+    - test_param_id: '*bastion'
+      ports:
+        - 22
+        - 2222

--- a/conftest.py
+++ b/conftest.py
@@ -176,6 +176,7 @@ def pytest_runtest_makereport(item, call):
         metadata = get_metadata_from_funcargs(item.funcargs)
         markers = {k: serialize_marker(v) for (k, v) in get_node_markers(item).items()}
         severity = markers.get('severity', None) and markers.get('severity')['args'][0]
+        regression = markers.get('regression', None) and markers.get('regression')['args'][0]
         outcome, reason = get_outcome_and_reason(report, markers, call)
         rationale = markers.get('rationale', None) and \
             clean_docstring(markers.get('rationale')['args'][0])
@@ -191,5 +192,6 @@ def pytest_runtest_makereport(item, call):
             rationale=rationale,
             reason=reason,
             severity=severity,
+            regression=regression,
             unparametrized_name=item.originalname,
         )

--- a/conftest.py
+++ b/conftest.py
@@ -11,7 +11,6 @@ import custom_config
 
 
 botocore_client = None
-whitelisted_ports = None
 
 
 def pytest_addoption(parser):
@@ -54,14 +53,11 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     global botocore_client
-    global whitelisted_ports
 
     # monkeypatch cache.set to serialize datetime.datetime's
     patch_cache_set(config)
 
     profiles, regions = config.getoption('--aws-profiles'), config.getoption('--aws-regions')
-
-    whitelisted_ports = frozenset([int(port) for port in config.getoption('--aws-whitelisted-ports')])
 
     botocore_client = BotocoreClient(
         profiles=profiles,

--- a/conftest.py
+++ b/conftest.py
@@ -30,17 +30,6 @@ def pytest_addoption(parser):
                      action='store_true',
                      help='Log whether AWS API calls hit the cache. Requires -s')
 
-    parser.addoption('--aws-require-tags',
-                     nargs='*',
-                     default=[],
-                     help='EC2 instance tags for the aws.ec2.test_ec2_instance_has_required_tags test to check.')
-
-    parser.addoption('--aws-whitelisted-ports',
-                     nargs='*',
-                     default=[],
-                     help='Additional ports to whitelist for '
-                          'aws.ec2.test_ec2_security_group_opens_specific_ports_to_all test.')
-
     parser.addoption('--offline',
                      action='store_true',
                      default=False,
@@ -68,10 +57,6 @@ def pytest_configure(config):
         offline=config.getoption('--offline'))
 
     config.custom_config = custom_config.CustomConfig(config.getoption('--config'))
-    config.custom_config.overlay_cli_opts({
-        'aws-require-tags': config.getoption('--aws-require-tags'),
-        'aws-whitelisted-ports': frozenset([int(port) for port in config.getoption('--aws-whitelisted-ports')])
-    })
 
 
 @pytest.fixture

--- a/custom_config.py
+++ b/custom_config.py
@@ -1,0 +1,58 @@
+import re
+
+import yaml
+
+import exemptions
+import severity
+import regressions
+
+
+class CustomConfig:
+
+    def __init__(self, config_fd):
+        parsed_config = {}
+        if config_fd is not None:
+            parsed_config = yaml.load(config_fd)
+        self.aws = AWSConfig(parsed_config.get('aws', {}))
+        self.exemptions = exemptions.load(parsed_config.get('exemptions'))
+        self.severities = severity.load(parsed_config.get('severities'))
+        self.regressions = regressions.load(parsed_config.get('regressions'))
+
+    def overlay_cli_opts(self, cli_opts):
+        self.aws.overlay_cli_opts(cli_opts)
+        return
+
+    def add_markers(self, item):
+        severity.add_severity_marker(item)
+        exemptions.add_xfail_marker(item)
+        regressions.add_regression_marker(item)
+
+
+class AWSConfig:
+
+    def __init__(self, config):
+        self.required_tags = frozenset(config.get('required_tags', []))
+        self.whitelisted_ports_global = set(config.get('whitelisted_ports_global', []))
+        self.whitelisted_ports = config.get('whitelisted_ports', [])
+
+    def overlay_cli_opts(self, cli_opts):
+        # TODO: move keys to consts
+        if 'aws-required-tags' in cli_opts:
+            self.required_tags = frozenset(cli_opts['aws-required-tags'])
+        if 'aws-whitelisted-ports' in cli_opts:
+            self.whitelisted_ports_global = set(cli_opts['aws-whitelisted-ports'])
+
+    def get_whitelisted_ports(self, test_id):
+        self.get_whitelisted_ports_from_test_id(test_id) + self.whitelisted_ports_global
+
+    def get_whitelisted_ports_from_test_id(self, test_id):
+        for rule in self.whitelisted_ports:
+            if rule['test_param_id'].startswith('*'):
+                substring = rule['test_param_id'][1:]
+                if re.search(substring, test_id):
+                    return set(rule['ports'])
+
+            if test_id == rule['test_param_id']:
+                return set(rule['ports'])
+
+        return set([])

--- a/custom_config.py
+++ b/custom_config.py
@@ -18,10 +18,6 @@ class CustomConfig:
         self.severities = severity.load(parsed_config.get('severities'))
         self.regressions = regressions.load(parsed_config.get('regressions'))
 
-    def overlay_cli_opts(self, cli_opts):
-        self.aws.overlay_cli_opts(cli_opts)
-        return
-
     def add_markers(self, item):
         severity.add_severity_marker(item)
         exemptions.add_xfail_marker(item)
@@ -34,12 +30,6 @@ class AWSConfig:
         self.required_tags = frozenset(config.get('required_tags', []))
         self.whitelisted_ports_global = set(config.get('whitelisted_ports_global', []))
         self.whitelisted_ports = config.get('whitelisted_ports', [])
-
-    def overlay_cli_opts(self, cli_opts):
-        if len(cli_opts['aws-require-tags']):
-            self.required_tags = frozenset(cli_opts['aws-require-tags'])
-        if len(cli_opts['aws-whitelisted-ports']):
-            self.whitelisted_ports_global = set(cli_opts['aws-whitelisted-ports'])
 
     def get_whitelisted_ports(self, test_id):
         return self.get_whitelisted_ports_from_test_id(test_id) | self.whitelisted_ports_global

--- a/custom_config.py
+++ b/custom_config.py
@@ -36,14 +36,13 @@ class AWSConfig:
         self.whitelisted_ports = config.get('whitelisted_ports', [])
 
     def overlay_cli_opts(self, cli_opts):
-        # TODO: move keys to consts
-        if 'aws-required-tags' in cli_opts:
-            self.required_tags = frozenset(cli_opts['aws-required-tags'])
-        if 'aws-whitelisted-ports' in cli_opts:
+        if len(cli_opts['aws-require-tags']):
+            self.required_tags = frozenset(cli_opts['aws-require-tags'])
+        if len(cli_opts['aws-whitelisted-ports']):
             self.whitelisted_ports_global = set(cli_opts['aws-whitelisted-ports'])
 
     def get_whitelisted_ports(self, test_id):
-        self.get_whitelisted_ports_from_test_id(test_id) + self.whitelisted_ports_global
+        return self.get_whitelisted_ports_from_test_id(test_id) | self.whitelisted_ports_global
 
     def get_whitelisted_ports_from_test_id(self, test_id):
         for rule in self.whitelisted_ports:

--- a/exemptions.conf.example
+++ b/exemptions.conf.example
@@ -1,7 +1,0 @@
-# pytest-sevices example exemptions conf
-#
-# this is a comment
-#
-# columns:
-# unparametrized test name; test_param_id; expiration day; expiration comment
-test_ec2_instance_has_required_tags i-0123456789f014c162 2019-01-01 ec2 instance has no owner

--- a/exemptions.py
+++ b/exemptions.py
@@ -79,7 +79,7 @@ def load(rules):
     ... }
     ... ]) == {'test_foo': {'foo-id': ('2050-01-01', 'in prod never allow foo')}}
     True
-    >>> # UserWarning: Line 1: Skipping line with duplicate test name and ID 'test_foo' 'foo-id'
+    >>> # UserWarning: Exemptions: test_name: test_foo | test_id: foo-id | Skipping duplicate test name and ID
 
     Does not check that test name and IDs exist (since names might not
     be collected and IDs can require an HTTP call).
@@ -95,14 +95,14 @@ def load(rules):
 
         if expiration < date.today():
             warnings.warn(
-                'Exemptions: test_name: {} | test_id: {} | Skipping line with expiration day in the past {!r}'
+                'Exemptions: test_name: {} | test_id: {} | Skipping rule with expiration day in the past {!r}'
                 .format(test_name, test_id, expiration)
             )
             continue
 
         if test_id in processed_rules[test_name]:
             warnings.warn(
-                'Exemptions: test_name: {} | test_id: {} | Skipping line with duplicate test name and ID'
+                'Exemptions: test_name: {} | test_id: {} | Skipping duplicate test name and ID'
                 .format(test_name, test_id)
             )
             continue

--- a/regressions.py
+++ b/regressions.py
@@ -8,7 +8,64 @@ import pytest
 
 def load(rules):
     """
-    TODO
+    Parses the regression section of the conf file and returns a two level dict with format:
+
+    {<test_name>:
+        {<test_id>: <comment>
+        ...
+        }
+    ...
+    }
+
+    Examples:
+
+    >>> load([
+    ... {
+    ... 'test_name': 'test_foo',
+    ... 'test_param_id': 'foo-id',
+    ... 'comment': 'foo bar baz!'
+    ... }
+    ... ]) == {'test_foo': {'foo-id': 'foo bar baz!'}}
+    True
+
+    >>> load([
+    ... {
+    ... 'test_name': 'test_foo',
+    ... 'test_param_id': 'foo-id',
+    ... 'comment': 'foo bar baz!'
+    ... },
+    ... {
+    ... 'test_name': 'test_foo',
+    ... 'test_param_id': 'bar-id',
+    ... 'comment': 'bar bar baz!'
+    ... }
+    ... ]) == {
+    ... 'test_foo': {
+    ... 'foo-id': 'foo bar baz!',
+    ... 'bar-id': 'bar bar baz!' }}
+    True
+
+
+    Duplicate test name and IDs are ignored with a warning:
+
+    >>> load([
+    ... {
+    ... 'test_name': 'test_foo',
+    ... 'test_param_id': 'foo-id',
+    ... 'comment': 'foo bar baz!'
+    ... },
+    ... {
+    ... 'test_name': 'test_foo',
+    ... 'test_param_id': 'foo-id',
+    ... 'comment': 'bar bar baz!'
+    ... }
+    ... ]) == {'test_foo': {'foo-id': 'foo bar baz!'}}
+    True
+    >>> # UserWarning: Regressions: test_name: test_foo | test_id: foo-id | Skipping duplicate test name and ID
+
+    Does not check that test name and IDs exist (since names might not
+    be collected and IDs can require an HTTP call).
+
     """
     processed_rules = defaultdict(dict)
 
@@ -20,7 +77,7 @@ def load(rules):
 
         if test_id in processed_rules[test_name]:
             warnings.warn(
-                'Regressions: test_name: {} | test_id: {} | Skipping line with duplicate test name and ID'
+                'Regressions: test_name: {} | test_id: {} | Skipping duplicate test name and ID'
                 .format(test_name, test_id)
             )
             continue

--- a/regressions.py
+++ b/regressions.py
@@ -1,0 +1,56 @@
+
+from collections import defaultdict
+import re
+import warnings
+
+import pytest
+
+
+def load(rules):
+    """
+    TODO
+    """
+    processed_rules = defaultdict(dict)
+
+    if not rules:
+        return processed_rules
+
+    for rule in rules:
+        test_name, test_id, comment = rule['test_name'], rule['test_param_id'], rule['comment']
+
+        if test_id in processed_rules[test_name]:
+            warnings.warn(
+                'Regressions: test_name: {} | test_id: {} | Skipping line with duplicate test name and ID'
+                .format(test_name, test_id)
+            )
+            continue
+
+        processed_rules[test_name][test_id] = comment
+
+    return processed_rules
+
+
+# TODO: This is fairly similar to exemptions.add_xfail_marker
+def add_regression_marker(item):
+    """
+    Adds regression markers as specified in the config file.
+    """
+    if not item.get_marker('parametrize'):
+        warnings.warn('Skipping regression checks for test without resource name {!r}'.format(item.name))
+        return
+
+    test_regressions = item.config.custom_config.regressions.get(item.originalname, None)
+    test_id = item._genid
+
+    if test_regressions:
+        for regression_test_id in test_regressions:
+            if regression_test_id.startswith('*'):
+                substring = regression_test_id[1:]
+                if re.search(substring, test_id):
+                    comment = test_regressions[regression_test_id]
+                    item.add_marker(pytest.mark.regression(comment))
+                    return
+
+        if test_id in test_regressions:
+            comment = test_regressions[test_id]
+            item.add_marker(pytest.mark.regression(comment))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 botocore==1.8.24
 coverage==4.5
 flake8==3.5.0
+PyYAML==3.12
 pygerduty==0.37.0
 pytest-cov==2.5.1
 pytest-html==1.16.1

--- a/service_report_generator.py
+++ b/service_report_generator.py
@@ -35,9 +35,10 @@ Pytest Service JSON format:
        'reason':  # pytest test outcome reason if any (e.g. resource fetch failed)
        'markers':  # pytest markers on the test e.g. aws service, ruleset
        'metadata':  # additional metadata on the resource being tested
-       'rationale': # (optional) rationale behind the test.
-       'description': # (optional) description of the test
-       'severity': # (optional) severity of the test
+       'rationale': # (optional) rationale behind the test. (null if not set)
+       'description': # (optional) description of the test (null if not set)
+       'severity': # (optional) severity of the test (null if not set)
+       'regression': # (optional) regression comment (null if not set)
     },
     ...
   ]
@@ -312,6 +313,7 @@ def get_result_for_test(test):
         'rationale': meta['rationale'],
         'description': meta['description'],
         'severity': meta['severity'],
+        'regression': meta['regression'],
     }
 
 

--- a/severity.conf.example
+++ b/severity.conf.example
@@ -1,3 +1,0 @@
-# pytest-sevices example severity conf
-test_ec2_instance_has_required_tags	INFO
-*  WARN

--- a/severity.py
+++ b/severity.py
@@ -14,7 +14,7 @@ SEVERITY_LEVELS = [
 ]
 
 
-def parse_conf_file(conf_fd):
+def load(rules):
     """
     Parses an open severity conf file and returns a dict of test name to severity level for tests.
 
@@ -70,37 +70,30 @@ def parse_conf_file(conf_fd):
     Does not check that test names exist (since they might not be collected).
     """
     # dict of test name to severity level
-    rules = {}
+    processed_rules = {}
 
-    if not conf_fd:
-        return rules
+    if not rules:
+        return processed_rules
 
-    for line_number, line in enumerate(conf_fd):
-        if line.startswith('#'):
-            continue
+    for rule in rules:
+        test_name, severity = rule['test_name'], rule['severity']
 
-        line_parts = line.split()
-        if len(line_parts) < 2:
-            warnings.warn('Line {}: Skipping line with fewer than 2 whitespace delimited parts.'.format(line_number))
-            continue
-
-        test_name, severity = line_parts[0], line_parts[1]
         if severity not in SEVERITY_LEVELS:
-            warnings.warn('Line {}: Skipping line with invalid severity level {!r}'.format(line_number, severity))
+            warnings.warn('test_name: {} | Skipping line with invalid severity level {!r}'.format(test_name, severity))
             continue
 
-        if test_name in rules:
-            warnings.warn('Line {}: Skipping line with duplicate test name {!r}'.format(line_number, test_name))
+        if test_name in processed_rules:
+            warnings.warn('test_name: {} | Skipping line with duplicate test name'.format(test_name))
             continue
 
-        rules[test_name] = severity
+        processed_rules[test_name] = severity
 
-    if '*' in rules:
-        rules_with_default = defaultdict(lambda: rules['*'], **rules)
+    if '*' in processed_rules:
+        rules_with_default = defaultdict(lambda: processed_rules['*'], **processed_rules)
         del rules_with_default['*']
         return rules_with_default
     else:
-        return rules
+        return processed_rules
 
 
 def add_severity_marker(item):
@@ -111,8 +104,8 @@ def add_severity_marker(item):
     """
     test_name_for_matching = item.originalname or item.name
 
-    if test_name_for_matching in item.config.severity:
-        conf_severity = item.config.severity[test_name_for_matching]
+    if test_name_for_matching in item.config.custom_config.severities:
+        conf_severity = item.config.custom_config.severities[test_name_for_matching]
         test_severity = item.get_marker("severity")
         if test_severity and test_severity.args[0] != conf_severity:
             warnings.warn('Overriding existing severity {} for test {}'.format(

--- a/severity.py
+++ b/severity.py
@@ -16,54 +16,29 @@ SEVERITY_LEVELS = [
 
 def load(rules):
     """
-    Parses an open severity conf file and returns a dict of test name to severity level for tests.
+    Parses severities section of the conf file and returns a dict of test name to severity level for tests.
 
-    The files consist of:
-
-    comment lines that have the format:
-
-    '#'<anything>\n
-
-    test severity lines that have either of the formats:
-
-    <test matcher><whitespace><severity>\n
-
-    <test matcher><whitespace><severity><whitespace><comment>\n
-
-    where:
-
-    <anything> := is any non newline character
-    <test matcher> := is an unparametrized test name or '*' to match all tests
-    <severity> := is one of INFO, WARN, or ERROR
-    <whitespace> := anything str.split i.e. one or more ' ', '\t', or '\n' chars
-
-    >>> from io import StringIO
-    >>> parse_conf_file(StringIO('# comment'))
-    {}
-    >>> parse_conf_file(StringIO('test_foo ERROR in prod never allow foo'))
+    >>> load([{'test_name': 'test_foo', 'severity': 'ERROR'}])
     {'test_foo': 'ERROR'}
-    >>> parse_conf_file(StringIO('* INFO'))  # doctest:+ELLIPSIS
-    defaultdict(<function parse_conf_file.<locals>.<lambda> at 0x...>, {})
-    >>> parse_conf_file(StringIO('test_foo ERROR\\ntest_bar INFO')) == {'test_foo': 'ERROR', 'test_bar': 'INFO'}
+    >>> load([{'test_name': '*', 'severity': 'INFO'}])  # doctest:+ELLIPSIS
+    defaultdict(<function load.<locals>.<lambda> at 0x...>, {})
+    >>> load([
+    ... {'test_name': 'test_foo', 'severity': 'ERROR'}, {'test_name': 'test_bar', 'severity': 'INFO'}
+    ... ]) == {'test_foo': 'ERROR', 'test_bar': 'INFO'}
     True
-
-    Short lines are skipped with a warning:
-
-    >>> parse_conf_file(StringIO('invalid'))
-    {}
-    >>> # UserWarning: Line 0: Skipping line with fewer than 2 whitespace delimited parts.
-
 
     Invalid severity levels are skipped with a warning:
 
-    >>> parse_conf_file(StringIO('test AHHH!'))
+    >>> load([{'test_name': 'test_foo', 'severity': 'AHHH!'}])
     {}
     >>> # UserWarning: Line 0: Skipping line with invalid severity level 'AHHH!'
 
 
     Duplicate test names are ignored with a warning:
 
-    >>> parse_conf_file(StringIO('test_foo INFO\\ntest_foo WARN')) == {'test_foo': 'INFO'}
+    >>> load([
+    ... {'test_name': 'test_foo', 'severity': 'ERROR'}, {'test_name': 'test_foo', 'severity': 'INFO'}
+    ... ]) == {'test_foo': 'ERROR'}
     True
     >>> # UserWarning: Line 1: Skipping line with duplicate test name 'test_foo'
 


### PR DESCRIPTION
This refactors the separate exemptions and severity config into a single big YAML config. It also adds the ability to mark regressions and have security group specific whitelisted ports (fixing #92).

(I have not finished the changes required to the `README.md`. Would prefer to wait for the initial review before finishing it up.)

r? @g-k - mind giving this an initial once over?