### PR TITLE
Only get running or pending ec2 instances

### DIFF
--- a/aws/ec2/resources.py
+++ b/aws/ec2/resources.py
@@ -17,7 +17,11 @@ def ec2_instances():
     "http://botocore.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.describe_instances"
     # Note: extracting Reservations.Instances drops EC2-Classic Groups at Reservations.Groups
     return botocore_client.get(
-        'ec2', 'describe_instances', [], {})\
+            'ec2',
+            'describe_instances',
+            [],
+            {'Filters': [{'Name': 'instance-state-name', 'Values': ['pending', 'running']}]}
+        )\
         .extract_key('Reservations')\
         .flatten()\
         .extract_key('Instances')\


### PR DESCRIPTION
In the spirit of returning actionable results, lets not include anything stopped/terminated or security groups associated with them.

r? @g-k 