### PR TITLE
test_iam_user_is_inactive with config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,10 +202,10 @@ regressions:
     comment: this was remediated by ops team
 aws:
   user_is_inactive:
-    considered_inactive:
+    no_activity_since:
       years: 1
       months: 0
-    grace_period:
+    created_after:
       weeks: 1
   required_tags:
     - Name
@@ -377,13 +377,15 @@ The config looks like:
 ```
 ...
 aws:
-  # Configuration on the relative time for what is considered inactive and what the grace period is within
-  # the test_iam_user_is_inactive
+  # Relative time delta for test_iam_user_is_inactive. no_activity_since will be used as the failure marker,
+  # so in this example any user that hasn't had any activity for a year will be marked as a "failure". created_after
+  # is used as a grace period, so in this case any user that was created within the last week will be automatically
+  # pass this test.
   user_is_inactive:
-    considered_inactive:
+    no_activity_since:
       years: 1
       months: 0
-    grace_period:
+    created_after:
       weeks: 1
   # Required tags used within the test_ec2_instance_has_required_tags test
   required_tags:

--- a/README.md
+++ b/README.md
@@ -201,6 +201,12 @@ regressions:
     test_param_id: '*mycustomgroup'
     comment: this was remediated by ops team
 aws:
+  user_is_inactive:
+    considered_inactive:
+      years: 1
+      months: 0
+    grace_period:
+      weeks: 1
   required_tags:
     - Name
     - Type
@@ -371,6 +377,14 @@ The config looks like:
 ```
 ...
 aws:
+  # Configuration on the relative time for what is considered inactive and what the grace period is within
+  # the test_iam_user_is_inactive
+  user_is_inactive:
+    considered_inactive:
+      years: 1
+      months: 0
+    grace_period:
+      weeks: 1
   # Required tags used within the test_ec2_instance_has_required_tags test
   required_tags:
     - Name

--- a/aws/iam/helpers.py
+++ b/aws/iam/helpers.py
@@ -1,0 +1,85 @@
+from dateutil.parser import parse
+
+
+def user_is_inactive(iam_user, grace_period, considered_inactive):
+    """
+    Returns False if any of these are true:
+        - The user was created less than the grace period
+        - The user has used either possibly active access keys since the date
+          that is "considered_inactive"
+        - The user has logged into the AWS console since the date that is
+          "considered_inactive"
+    else it will return True.
+
+    >>> from datetime import datetime
+    >>> grace_period = datetime(2018, 1, 8)
+    >>> considered_inactive = datetime(2017, 1, 1)
+
+    >>> user_is_inactive({'user_creation_time': '2018-01-10'}, grace_period, considered_inactive)
+    False
+
+    >>> user_is_inactive({
+    ...     'user_creation_time': '2016-01-10',
+    ...     'access_key_1_active': 'true',
+    ...     'access_key_1_last_used_date': '2017-06-01',
+    ... }, grace_period, considered_inactive)
+    False
+
+    >>> user_is_inactive({
+    ...     'user_creation_time': '2010-01-10',
+    ...     'access_key_1_active': 'true',
+    ...     'access_key_1_last_used_date': '2014-06-01',
+    ...     'access_key_2_active': 'true',
+    ...     'access_key_2_last_used_date': '2017-02-01',
+    ... }, grace_period, considered_inactive)
+    False
+
+    >>> user_is_inactive({
+    ...     'user_creation_time': '2010-01-10',
+    ...     'access_key_1_active': 'true',
+    ...     'access_key_1_last_used_date': '2014-06-01',
+    ...     'access_key_2_active': 'false',
+    ...     'access_key_2_last_used_date': 'N/A',
+    ...     'password_enabled': 'true',
+    ...     'password_last_used': '2017-09-01',
+    ... }, grace_period, considered_inactive)
+    False
+
+    >>> user_is_inactive({
+    ...     'user_creation_time': '2016-01-10',
+    ...     'access_key_1_active': 'true',
+    ...     'access_key_1_last_used_date': '2016-06-01',
+    ...     'access_key_2_active': 'false',
+    ...     'access_key_2_last_used_date': 'N/A',
+    ...     'password_enabled': 'false',
+    ...     'password_last_used': 'N/A',
+    ... }, grace_period, considered_inactive)
+    True
+
+    >>> user_is_inactive({
+    ...     'user_creation_time': '2016-01-10',
+    ...     'access_key_1_active': 'false',
+    ...     'access_key_1_last_used_date': 'N/A',
+    ...     'access_key_2_active': 'false',
+    ...     'access_key_2_last_used_date': 'N/A',
+    ...     'password_enabled': 'true',
+    ...     'password_last_used': '2016-06-01',
+    ... }, grace_period, considered_inactive)
+    True
+    """
+
+    if parse(iam_user['user_creation_time']) > grace_period:
+        return False
+
+    if iam_user['access_key_1_active'] == 'true' and iam_user['access_key_1_last_used_date'] != 'N/A':
+        if parse(iam_user['access_key_1_last_used_date']) > considered_inactive:
+            return False
+    if iam_user['access_key_2_active'] == 'true' and iam_user['access_key_2_last_used_date'] != 'N/A':
+        if parse(iam_user['access_key_2_last_used_date']) > considered_inactive:
+            return False
+    if iam_user['password_enabled'] == 'true' and \
+            iam_user['password_last_used'] not in ['N/A', 'no_information']:
+        if parse(iam_user['password_last_used']) > considered_inactive:
+            return False
+
+    return True

--- a/aws/iam/test_iam_user_is_inactive.py
+++ b/aws/iam/test_iam_user_is_inactive.py
@@ -5,13 +5,13 @@ from aws.iam.helpers import user_is_inactive
 
 
 @pytest.fixture
-def considered_inactive(pytestconfig):
-    return pytestconfig.custom_config.aws.considered_inactive()
+def no_activity_since(pytestconfig):
+    return pytestconfig.custom_config.aws.no_activity_since()
 
 
 @pytest.fixture
-def grace_period(pytestconfig):
-    return pytestconfig.custom_config.aws.grace_period()
+def created_after(pytestconfig):
+    return pytestconfig.custom_config.aws.created_after()
 
 
 @pytest.mark.iam
@@ -19,13 +19,13 @@ def grace_period(pytestconfig):
         'iam_user_row',
         iam_get_credential_report(),
         ids=lambda user: user['user'])
-def test_iam_user_is_inactive(iam_user_row, considered_inactive, grace_period):
+def test_iam_user_is_inactive(iam_user_row, no_activity_since, created_after):
     """Tests if a user is inactive. This is done by checking the last time
     an access key was used or the user logged into the console. If the config
     settings are not present, it defaults to considering a year ago as inactive
-    and giving a user a 1 week grace period.
+    and giving a user a 1 week grace period (created_after).
     """
-    assert not user_is_inactive(iam_user_row, grace_period, considered_inactive), \
+    assert not user_is_inactive(iam_user_row, no_activity_since, created_after), \
         "User {} hasn't been used since {} and is out of the grace period.".format(
-            iam_user_row['user'], considered_inactive.date()
+            iam_user_row['user'], no_activity_since.date()
         )

--- a/aws/iam/test_iam_user_is_inactive.py
+++ b/aws/iam/test_iam_user_is_inactive.py
@@ -1,0 +1,31 @@
+import pytest
+
+from aws.iam.resources import iam_get_credential_report
+from aws.iam.helpers import user_is_inactive
+
+
+@pytest.fixture
+def considered_inactive(pytestconfig):
+    return pytestconfig.custom_config.aws.considered_inactive()
+
+
+@pytest.fixture
+def grace_period(pytestconfig):
+    return pytestconfig.custom_config.aws.grace_period()
+
+
+@pytest.mark.iam
+@pytest.mark.parametrize(
+        'iam_user_row',
+        iam_get_credential_report(),
+        ids=lambda user: user['user'])
+def test_iam_user_is_inactive(iam_user_row, considered_inactive, grace_period):
+    """Tests if a user is inactive. This is done by checking the last time
+    an access key was used or the user logged into the console. If the config
+    settings are not present, it defaults to considering a year ago as inactive
+    and giving a user a 1 week grace period.
+    """
+    assert not user_is_inactive(iam_user_row, grace_period, considered_inactive), \
+        "User {} hasn't been used since {} and is out of the grace period.".format(
+            iam_user_row['user'], considered_inactive.date()
+        )

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -23,10 +23,10 @@ regressions:
     comment: this was remediated by ops team
 aws:
   user_is_inactive:
-    considered_inactive:
+    no_activity_since:
       years: 1
       months: 0
-    grace_period:
+    created_after:
       weeks: 1
   required_tags:
     - Name

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -22,6 +22,12 @@ regressions:
     test_param_id: '*mycustomgroup'
     comment: this was remediated by ops team
 aws:
+  user_is_inactive:
+    considered_inactive:
+      years: 1
+      months: 0
+    grace_period:
+      weeks: 1
   required_tags:
     - Name
     - Type

--- a/custom_config.py
+++ b/custom_config.py
@@ -49,17 +49,17 @@ class AWSConfig:
 
         return set([])
 
-    def considered_inactive(self):
-        considered_inactive = self._parse_user_is_inactive_relative_time('considered_inactive')
-        if considered_inactive is None:
+    def no_activity_since(self):
+        no_activity_since = self._parse_user_is_inactive_relative_time('no_activity_since')
+        if no_activity_since is None:
             return datetime.now(timezone.utc)-relativedelta(years=+1)
-        return considered_inactive
+        return no_activity_since
 
-    def grace_period(self):
-        grace_period = self._parse_user_is_inactive_relative_time('grace_period')
-        if grace_period is None:
+    def created_after(self):
+        created_after = self._parse_user_is_inactive_relative_time('created_after')
+        if created_after is None:
             return datetime.now(timezone.utc)-relativedelta(weeks=+1)
-        return grace_period
+        return created_after
 
     def _parse_user_is_inactive_relative_time(self, key):
         if self.user_is_inactive.get(key) is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pytest-html==1.16.1
 pytest-json==0.4.0
 pytest-metadata==1.5.1
 pytest==3.3.2
+python-dateutil==2.6.1


### PR DESCRIPTION
`test_iam_user_is_inactive` will fail on users considered "inactive". What is considered inactive by default is "Hasn't used the account in over a year from when the test is run" and there is a default grace period of 1 week on new accounts (since they may not have used the account at all yet). Config supports years, months, and weeks for relative "time ago".

Fixes #98

r? @g-k 