### PR TITLE
Initial IAM test + refactor of GCPClient

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -20,9 +20,9 @@ def pytest_addoption(parser):
                      nargs='*',
                      help='Set default AWS profiles to use. Defaults to the current AWS profile i.e. [None].')
 
-    parser.addoption('--gcp-project-ids',
-                     nargs='*',
-                     help='Set GCP projects to test. Required for GCP tests.')
+    parser.addoption('--gcp-project-id',
+                     type=str,
+                     help='Set GCP project to test. Required for GCP tests.')
 
     parser.addoption('--debug-calls',
                      action='store_true',
@@ -50,7 +50,7 @@ def pytest_configure(config):
     patch_cache_set(config)
 
     profiles = config.getoption('--aws-profiles')
-    project_ids = config.getoption('--gcp-project-ids')
+    project_id = config.getoption('--gcp-project-id')
 
     botocore_client = BotocoreClient(
         profiles=profiles,
@@ -60,7 +60,7 @@ def pytest_configure(config):
         offline=config.getoption('--offline'))
 
     gcp_client = GCPClient(
-        project_ids=project_ids,
+        project_id=project_id,
         cache=config.cache,
         debug_calls=config.getoption('--debug-calls'),
         debug_cache=config.getoption('--debug-cache'),

--- a/gcp/client.py
+++ b/gcp/client.py
@@ -15,78 +15,114 @@ def cache_key(project_id, version, product, subproduct):
 class GCPClient:
 
     def __init__(self,
-                 project_ids,
+                 project_id,
                  cache,
                  debug_calls,
                  debug_cache,
                  offline):
-        self.project_ids = project_ids
+        self.project_id = project_id
         self.cache = cache
         self.debug_calls = debug_calls
         self.debug_cache = debug_cache
         self.offline = offline
 
-    def get(self, product, subproduct, version="v1", call_kwargs=None):
+    def list(self, product, subproduct, version="v1", results_key='items', call_kwargs=None):
+        """Public list func. See _list func docstring for more info"""
         if self.offline:
             results = []
         else:
-            results = list(self._get(product, subproduct, version, call_kwargs))
+            results = list(self._list(product, subproduct, version, results_key, call_kwargs))
         return results
 
-    def _get(self, product, subproduct, version="v1", call_kwargs=None):
+    def _list(self, product, subproduct, version="v1", results_key='items', call_kwargs=None):
+        """
+        Internal function for calling .list() on some service's resource. Supports debug printing
+        and caching of the response.
+
+        If you want empty call kwargs, pass in `{}`.
+        """
         if call_kwargs is None:
-            call_kwargs = {}
+            call_kwargs = {'project': self.project_id}
 
-        for project_id in self.project_ids:
-            ckey = cache_key(project_id, version, product, subproduct)
-            cached_result = self.cache.get(ckey, None)
-            if cached_result is not None:
-                print('found cached value for', ckey)
-                return cached_result
+        ckey = cache_key(self.project_id, version, product, subproduct)
+        cached_result = self.cache.get(ckey, None)
+        if cached_result is not None:
+            print('found cached value for', ckey)
+            return cached_result
 
-            service = self._service(product, version)
-            api_entity = getattr(service, subproduct)()
+        results = self._get_list_results(product, subproduct, version, results_key, call_kwargs)
 
-            if self.debug_calls:
-                print('calling', api_entity)
+        if self.debug_cache:
+            print('setting cache value for', ckey)
 
-            if self._zone_aware(product, subproduct):
-                results = []
-                for zone in self._get_zones(project_id):
-                    results = sum(
-                        [results],
-                        self._get_all_items(api_entity, {**call_kwargs, 'project': project_id, 'zone': zone})
+        self.cache.set(ckey, results)
+
+        return results
+
+    def _get_list_results(self, product, subproduct, version, results_key, call_kwargs):
+        """
+        Internal helper for actually constructing the .list() function call and calling it.
+
+        If a service supports "zones", then loop through each zone to collect all resources from
+        that service. An example of this is collecting all compute instances (compute.instances().list()).
+        """
+        service = self._service(product, version)
+
+        api_entity = getattr(service, subproduct.split('.')[0])()
+        for entity in subproduct.split('.')[1:]:
+            api_entity = getattr(api_entity, entity)()
+
+        if self.debug_calls:
+            print('calling', api_entity)
+
+        if self._zone_aware(product, subproduct):
+            results = []
+            for zone in self._list_zones():
+                results = sum(
+                    [results],
+                    self._list_all_items(
+                        api_entity,
+                        {**call_kwargs, 'zone': zone},
+                        results_key
                     )
-            else:
-                results = self._get_all_items(api_entity, {**call_kwargs, 'project': project_id})
+                )
+        else:
+            results = self._list_all_items(api_entity, call_kwargs, results_key)
 
-            if self.debug_cache:
-                print('setting cache value for', ckey)
+        return results
 
-            self.cache.set(ckey, results)
-
-            return results
-
-    def _get_all_items(self, api_entity, call_kwargs):
+    def _list_all_items(self, api_entity, call_kwargs, results_key):
+        """Internal helper for dealing with pagination"""
         request = api_entity.list(**call_kwargs)
         items = []
         while request is not None:
             # TODO: exception handling on request.execute()
             resp = request.execute()
-            items = sum([items], resp.get("items", []))
-            request = api_entity.list_next(request, resp)
+            items = sum([items], resp.get(results_key, []))
+            try:
+                request = api_entity.list_next(request, resp)
+            except AttributeError:
+                request = None
         return items
 
     def _service(self, product, version="v1"):
+        """Internal helper around google client lib's build service func"""
         return build_service(product, version)
 
     def _zone_aware(self, product, subproduct):
+        """
+        Internal helper for whether or not a product and subproduct take zones into account.
+
+        Differing heavily from AWS, most GCP services do not take zones into account with API
+        calls and such.
+        """
         if product == "compute" and subproduct == "instances":
             return True
         return False
 
-    def _get_zones(self, project_id):
+    def _list_zones(self):
+        """Internal helper for listing all zones"""
         # TODO: exception handling
-        response = self._service('compute').zones().list(project=project_id).execute()['items']
+        response = self._service('compute').zones().list(project=self.project_id).execute()['items']
         for result in response:
                 yield result['name']

--- a/gcp/client.py
+++ b/gcp/client.py
@@ -26,6 +26,11 @@ class GCPClient:
         self.debug_cache = debug_cache
         self.offline = offline
 
+    def get_project_id(self):
+        if self.offline:
+            return 'test'
+        return self.project_id
+
     def list(self, product, subproduct, version="v1", results_key='items', call_kwargs=None):
         """Public list func. See _list func docstring for more info"""
         if self.offline:

--- a/gcp/compute/resources.py
+++ b/gcp/compute/resources.py
@@ -2,15 +2,15 @@ from conftest import gcp_client
 
 
 def firewalls():
-    return gcp_client.get("compute", "firewalls")
+    return gcp_client.list("compute", "firewalls")
 
 
 def networks():
-    return gcp_client.get("compute", "networks")
+    return gcp_client.list("compute", "networks")
 
 
 def instances():
-    return gcp_client.get("compute", "instances")
+    return gcp_client.list("compute", "instances")
 
 
 def networks_with_instances():

--- a/gcp/iam/helpers.py
+++ b/gcp/iam/helpers.py
@@ -1,0 +1,10 @@
+import datetime
+
+
+def is_service_account_key_old(service_account_key):
+    """
+    Tests whether a service account key is older than 90 days.
+    """
+    creation_date = datetime.datetime.strptime(service_account_key['validAfterTime'][:10], "%Y-%m-%d")
+    # TODO: Make configurable
+    return (creation_date > datetime.datetime.now() - datetime.timedelta(days=90))

--- a/gcp/iam/resources.py
+++ b/gcp/iam/resources.py
@@ -1,0 +1,25 @@
+from conftest import gcp_client
+
+
+def service_accounts():
+    return gcp_client.list(
+        "iam",
+        "projects.serviceAccounts",
+        results_key="accounts",
+        call_kwargs={'name': 'projects/'+gcp_client.project_id}
+    )
+
+
+def service_account_keys(service_account):
+    return gcp_client.list(
+        "iam",
+        "projects.serviceAccounts.keys",
+        results_key="keys",
+        call_kwargs={'name': service_account['name']}
+    )
+
+
+def all_service_account_keys():
+    for sa in service_accounts():
+        for key in service_account_keys(sa):
+            yield key

--- a/gcp/iam/resources.py
+++ b/gcp/iam/resources.py
@@ -6,7 +6,7 @@ def service_accounts():
         "iam",
         "projects.serviceAccounts",
         results_key="accounts",
-        call_kwargs={'name': 'projects/'+gcp_client.project_id}
+        call_kwargs={'name': 'projects/'+gcp_client.get_project_id()}
     )
 
 

--- a/gcp/iam/test_service_account_key_is_old.py
+++ b/gcp/iam/test_service_account_key_is_old.py
@@ -1,0 +1,13 @@
+import pytest
+
+from gcp.iam.resources import all_service_account_keys
+from gcp.iam.helpers import is_service_account_key_old
+
+
+@pytest.mark.gcp_iam
+@pytest.mark.parametrize('service_account_key',
+                         all_service_account_keys(),
+                         ids=lambda key: key['name'])
+def test_service_account_key_is_old(service_account_key):
+    """Tests if the Service Account Key is older than 90 days"""
+    assert is_service_account_key_old(service_account_key)

--- a/gcp/sql/resources.py
+++ b/gcp/sql/resources.py
@@ -2,4 +2,4 @@ from conftest import gcp_client
 
 
 def instances():
-    return gcp_client.get("sqladmin", "instances", version="v1beta4")
+    return gcp_client.list("sqladmin", "instances", version="v1beta4")


### PR DESCRIPTION
Adds the first IAM test, which tests whether service account keys
are older than 90 days. Refactored GCPClient to support IAM calls
as they function quite a bit differently from networking, compute,
and sql calls.

Also removed support for passing in multiple GCP project ids, as this is
a feature I have not found useful and makes the code a bit more complex.

r? @g-k 