### PR TITLE
Beginnings of implementing forensics-ready tests

### DIFF
--- a/aws/client.py
+++ b/aws/client.py
@@ -170,6 +170,11 @@ class BotocoreClient:
 
         self.results = []
 
+    def get_regions(self):
+        if self.offline:
+            return []
+        return self.regions
+
     def get(self,
             service_name,
             method_name,

--- a/aws/cloudtrail/resources.py
+++ b/aws/cloudtrail/resources.py
@@ -1,0 +1,18 @@
+from conftest import botocore_client
+
+
+def cloudtrails():
+    "https://botocore.readthedocs.io/en/latest/reference/services/cloudtrail.html#CloudTrail.Client.describe_trails"
+    trails = botocore_client.get(
+        'cloudtrail', 'describe_trails', [], {})\
+        .extract_key('trailList')\
+        .flatten()\
+        .values()
+
+    # This is due to the fact that if you have a multi region cloudtrail, it will be included for each region.
+    unique_trails = []
+    for trail in trails:
+        if not any(t for t in unique_trails if t['TrailARN'] == trail['TrailARN']):
+            unique_trails.append(trail)
+
+    return unique_trails

--- a/aws/cloudtrail/test_cloudtrail_enabled_in_all_regions.py
+++ b/aws/cloudtrail/test_cloudtrail_enabled_in_all_regions.py
@@ -1,0 +1,20 @@
+import pytest
+
+from conftest import botocore_client
+
+from aws.cloudtrail.resources import cloudtrails
+
+
+@pytest.mark.cloudtrail
+@pytest.mark.parametrize('aws_region',
+                         botocore_client.regions,
+                         ids=lambda region: region)
+def test_cloudtrail_enabled_in_all_regions(aws_region):
+    """
+    Tests that all regions have an associated cloudtrail or that there is a cloudtrail for all regions.
+    """
+    trails = cloudtrails()
+    assert any(
+        trail for trail in trails
+        if trail['HomeRegion'] == aws_region or trail['IsMultiRegionTrail']
+    )

--- a/aws/cloudtrail/test_cloudtrail_enabled_in_all_regions.py
+++ b/aws/cloudtrail/test_cloudtrail_enabled_in_all_regions.py
@@ -12,8 +12,7 @@ def all_cloudtrails():
 
 @pytest.mark.cloudtrail
 @pytest.mark.parametrize('aws_region',
-                         botocore_client.regions,
-                         ids=lambda region: region)
+                         botocore_client.get_regions())
 def test_cloudtrail_enabled_in_all_regions(aws_region, all_cloudtrails):
     """
     Tests that all regions have an associated cloudtrail or that there is a cloudtrail for all regions.

--- a/aws/cloudtrail/test_cloudtrail_enabled_in_all_regions.py
+++ b/aws/cloudtrail/test_cloudtrail_enabled_in_all_regions.py
@@ -5,16 +5,20 @@ from conftest import botocore_client
 from aws.cloudtrail.resources import cloudtrails
 
 
+@pytest.fixture
+def all_cloudtrails():
+    return cloudtrails()
+
+
 @pytest.mark.cloudtrail
 @pytest.mark.parametrize('aws_region',
                          botocore_client.regions,
                          ids=lambda region: region)
-def test_cloudtrail_enabled_in_all_regions(aws_region):
+def test_cloudtrail_enabled_in_all_regions(aws_region, all_cloudtrails):
     """
     Tests that all regions have an associated cloudtrail or that there is a cloudtrail for all regions.
     """
-    trails = cloudtrails()
     assert any(
-        trail for trail in trails
+        trail for trail in all_cloudtrails
         if trail['HomeRegion'] == aws_region or trail['IsMultiRegionTrail']
     )

--- a/aws/cloudtrail/test_cloudtrail_log_validation_enabled.py
+++ b/aws/cloudtrail/test_cloudtrail_log_validation_enabled.py
@@ -1,0 +1,14 @@
+import pytest
+
+from aws.cloudtrail.resources import cloudtrails
+
+
+@pytest.mark.cloudtrail
+@pytest.mark.parametrize('cloudtrail',
+                         cloudtrails(),
+                         ids=lambda trail: trail['Name'])
+def test_cloudtrail_log_validation_enabled(cloudtrail):
+    """
+    Tests that all Cloudtrails have log validation enabled.
+    """
+    assert cloudtrail['LogFileValidationEnabled']

--- a/aws/ec2/resources.py
+++ b/aws/ec2/resources.py
@@ -47,6 +47,24 @@ def ec2_ebs_volumes():
         .values()
 
 
+def ec2_flow_logs():
+    "https://botocore.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.describe_flow_logs"
+    return botocore_client.get(
+        'ec2', 'describe_flow_logs', [], {})\
+        .extract_key('FlowLogs')\
+        .flatten()\
+        .values()
+
+
+def ec2_vpcs():
+    "https://botocore.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.describe_vpcs"
+    return botocore_client.get(
+        'ec2', 'describe_vpcs', [], {})\
+        .extract_key('Vpcs')\
+        .flatten()\
+        .values()
+
+
 def ec2_security_groups_with_in_use_flag():
     """Returns security groups with an additional "InUse" key,
     which is True if it is associated with at least one resource.

--- a/aws/ec2/test_ec2_security_group_opens_all_ports.py
+++ b/aws/ec2/test_ec2_security_group_opens_all_ports.py
@@ -1,5 +1,3 @@
-
-
 import pytest
 
 from aws.ec2.helpers import (

--- a/aws/ec2/test_ec2_vpc_flow_log_enabled.py
+++ b/aws/ec2/test_ec2_vpc_flow_log_enabled.py
@@ -1,17 +1,20 @@
 import pytest
 
-#from aws.ec2.helpers import ()
 from aws.ec2.resources import (
     ec2_flow_logs,
     ec2_vpcs
 )
 
 
+@pytest.fixture
+def all_flow_logs():
+    return ec2_flow_logs()
+
+
 @pytest.mark.ec2
 @pytest.mark.parametrize('ec2_vpc', ec2_vpcs(), ids=lambda vpc: vpc['VpcId'])
-def test_ec2_vpc_flow_log_enabled(ec2_vpc):
+def test_ec2_vpc_flow_log_enabled(ec2_vpc, all_flow_logs):
     """
     Checks that each VPC has VPC Flow Logs enabled.
     """
-    flow_logs = ec2_flow_logs()
-    assert any(flow_log for flow_log in flow_logs if flow_log['ResourceId'] == ec2_vpc['VpcId'])
+    assert any(flow_log for flow_log in all_flow_logs if flow_log['ResourceId'] == ec2_vpc['VpcId'])

--- a/aws/ec2/test_ec2_vpc_flow_log_enabled.py
+++ b/aws/ec2/test_ec2_vpc_flow_log_enabled.py
@@ -1,0 +1,17 @@
+import pytest
+
+#from aws.ec2.helpers import ()
+from aws.ec2.resources import (
+    ec2_flow_logs,
+    ec2_vpcs
+)
+
+
+@pytest.mark.ec2
+@pytest.mark.parametrize('ec2_vpc', ec2_vpcs(), ids=lambda vpc: vpc['VpcId'])
+def test_ec2_vpc_flow_log_enabled(ec2_vpc):
+    """
+    Checks that each VPC has VPC Flow Logs enabled.
+    """
+    flow_logs = ec2_flow_logs()
+    assert any(flow_log for flow_log in flow_logs if flow_log['ResourceId'] == ec2_vpc['VpcId'])

--- a/aws/elasticsearch/test_elasticsearch_domains_have_logging_enabled.py
+++ b/aws/elasticsearch/test_elasticsearch_domains_have_logging_enabled.py
@@ -1,0 +1,20 @@
+import pytest
+
+from aws.elasticsearch.resources import elasticsearch_domains
+
+
+@pytest.mark.elasticsearch
+@pytest.mark.parametrize(
+        'es_domain',
+        elasticsearch_domains(),
+        ids=lambda es_domain: es_domain['ARN'])
+def test_elasticsearch_domains_have_logging_enabled(es_domain):
+    """
+    Tests whether an elasticsearch domain has logging enabled.
+    """
+    assert es_domain.get('LogPublishingOption') is not None, \
+        "Logging is disabled for {}".format(es_domain["DomainName"])
+    assert es_domain['LogPublishingOptions']['INDEX_SLOW_LOGS']['Enabled'], \
+        "Index Slow Logs are disabled for {}".format(es_domain["DomainName"])
+    assert es_domain['LogPublishingOptions']['SEARCH_SLOW_LOGS']['Enabled'], \
+        "Search Slow Logs are disabled for {}".format(es_domain["DomainName"])


### PR DESCRIPTION
This includes 4 new tests that are taken from prowler's
(https://github.com/toniblyx/prowler) set of "forensics-ready" tests.

These include 3 CIS Benchmark tests (2 for Cloudtrail and 1 for VPC Flow
Logs) and an additional test for logging being enabled on
ElasticSearchService Domains.

@g-k I would love your take on the current implementation of `test_cloudtrail_enabled_in_all_regions` and `test_ec2_vpc_flow_log_enabled`. I am doing a resource fetch within the test as I don't want these tests to not run if there are no cloudtrails or vpc flow logs. What do you think?

As well, tests are not passing due to the fact that `test_cloudtrail_enabled_in_all_regions` is tested on regions and there is a hardcoded list of `['us-east-1']` for when `--offline` is passed in. Will fix once I get the :+1: / :-1: from you on the above mentioned issue.
