### PR TITLE
Add test_iam_access_key_is_old with config options

### DIFF
--- a/aws/iam/resources.py
+++ b/aws/iam/resources.py
@@ -200,6 +200,22 @@ def iam_admin_roles():
     return [role for role in iam_roles_with_policies() if user_is_admin(role)]
 
 
+def iam_access_keys_for_user(username):
+    "https://botocore.readthedocs.io/en/latest/reference/services/iam.html#IAM.Client.list_access_keys"
+    return botocore_client.get(
+        'iam', 'list_access_keys', [], {'UserName': username})\
+        .extract_key('AccessKeyMetadata')\
+        .flatten()\
+        .values()
+
+
+def iam_get_all_access_keys():
+    return sum([
+        iam_access_keys_for_user(username=user['UserName'])
+        for user in iam_users()
+    ], [])
+
+
 def iam_generate_credential_report():
     "http://botocore.readthedocs.io/en/latest/reference/services/iam.html#IAM.Client.generate_credential_report"
     results = botocore_client.get('iam', 'generate_credential_report', [], {}, do_not_cache=True).results

--- a/aws/iam/test_iam_access_key_is_old.py
+++ b/aws/iam/test_iam_access_key_is_old.py
@@ -1,0 +1,18 @@
+import pytest
+
+from aws.iam.resources import iam_get_all_access_keys
+from aws.iam.helpers import is_access_key_expired
+
+
+@pytest.fixture
+def access_key_expiration_date(pytestconfig):
+    return pytestconfig.custom_config.aws.get_access_key_expiration_date()
+
+
+@pytest.mark.iam
+@pytest.mark.parametrize(
+        'iam_access_key',
+        iam_get_all_access_keys(),
+        ids=lambda access_key: access_key['UserName'])
+def test_iam_access_key_is_old(iam_access_key, access_key_expiration_date):
+    assert not is_access_key_expired(iam_access_key, access_key_expiration_date)

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -28,6 +28,9 @@ aws:
       months: 0
     created_after:
       weeks: 1
+  access_key_expires_after:
+    years: 1
+    months: 0
   required_tags:
     - Name
     - Type

--- a/custom_config.py
+++ b/custom_config.py
@@ -61,6 +61,7 @@ class AWSConfig(CustomConfigMixin):
         self.required_tags = frozenset(config.get('required_tags', []))
         self.whitelisted_ports_global = set(config.get('whitelisted_ports_global', []))
         self.whitelisted_ports = config.get('whitelisted_ports', [])
+        self.access_key_expires_after = config.get('access_key_expires_after', None)
         super().__init__(config)
 
     def get_whitelisted_ports(self, test_id):
@@ -77,6 +78,16 @@ class AWSConfig(CustomConfigMixin):
                 return set(rule['ports'])
 
         return set([])
+
+    def get_access_key_expiration_date(self):
+        if self.access_key_expires_after is None:
+            return datetime.now(timezone.utc)-relativedelta(years=+1)
+
+        return datetime.now(timezone.utc)-relativedelta(
+            years=+self.access_key_expires_after.get('years', 0),
+            months=+self.access_key_expires_after.get('months', 0),
+            weeks=+self.access_key_expires_after.get('weeks', 0)
+        )
 
 
 class GSuiteConfig(CustomConfigMixin):


### PR DESCRIPTION
test_iam_access_key_is_old tests whether an access key is
older than the configured expiration date with a default of a year.

r? @g-k 