### PR TITLE
Add Heroku support, take 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ install:
   - make install
 
 script:
-  - make coverage flake8
+  - make doctest coverage flake8

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ clean: clean-cache clean-python
 	# remember to deactivate your active virtual env
 
 clean-cache: check_venv
-	pytest --cache-clear --aws-profiles $(AWS_PROFILE)
+	pytest --cache-clear --offline
 
 clean-python:
 	find . -type d -name venv -prune -o -type d -name __pycache__ -print0 | xargs -0 rm -rf
@@ -34,7 +34,6 @@ doctest: check_venv
 	pytest --doctest-modules -s --offline --debug-calls
 
 coverage: check_venv
-	# pytest --cov-config .coveragerc --cov=. --doctest-modules -s --offline --debug-calls
 	pytest --cov-config .coveragerc --cov=. --cov-append \
 		--aws-profiles example-account \
 		-o python_files=meta_test*.py \
@@ -43,7 +42,7 @@ coverage: check_venv
 	coverage html
 
 flake8: check_venv
-	flake8 --max-line-length 120 $(shell find . -name '*.py' -not -path "./venv/*")
+	flake8 --max-line-length 120 $(shell git ls-files | grep \.py$$)
 
 install: venv
 	( . venv/bin/activate && pip install -r requirements.txt )

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ doctest: check_venv
 	pytest --doctest-modules -s --offline --debug-calls
 
 coverage: check_venv
-	pytest --cov-config .coveragerc --cov=. --doctest-modules -s --offline --debug-calls
+	# pytest --cov-config .coveragerc --cov=. --doctest-modules -s --offline --debug-calls
 	pytest --cov-config .coveragerc --cov=. --cov-append \
 		--aws-profiles example-account \
 		-o python_files=meta_test*.py \

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ doctest: check_venv
 	pytest --doctest-modules -s --offline --debug-calls
 
 coverage: check_venv
-	pytest --cov-config .coveragerc --cov=. --cov-append \
+	pytest --cov-config .coveragerc --cov=. \
 		--aws-profiles example-account \
 		-o python_files=meta_test*.py \
 		-o cache_dir=./example_cache/

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,14 @@ ifeq ($(VIRTUAL_ENV),)
 	$(error "Run pytest-services from a virtualenv (try 'make install && source venv/bin/activate')")
 endif
 
-clean: clean-cache
+clean: clean-cache clean-python
 	rm -rf venv
 
 clean-cache: check_venv
 	pytest --cache-clear --aws-profiles $(AWS_PROFILE)
+
+clean-python: check_venv
+	find . -type d -name venv -prune -o -type d -name __pycache__ -print0 | xargs -0 rm -rf
 
 doctest: check_venv
 	pytest --doctest-modules -s --offline --debug-calls
@@ -60,6 +63,7 @@ venv:
 	check_venv \
 	clean \
 	clean-cache \
+	clean-python \
 	flake8 \
 	install \
 	venv

--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,12 @@ endif
 
 clean: clean-cache clean-python
 	rm -rf venv
+	# remember to deactivate your active virtual env
 
 clean-cache: check_venv
 	pytest --cache-clear --aws-profiles $(AWS_PROFILE)
 
-clean-python: check_venv
+clean-python:
 	find . -type d -name venv -prune -o -type d -name __pycache__ -print0 | xargs -0 rm -rf
 
 doctest: check_venv

--- a/conftest.py
+++ b/conftest.py
@@ -8,6 +8,7 @@ from cache import patch_cache_set
 from aws.client import BotocoreClient
 from gcp.client import GCPClient
 from gsuite.client import GsuiteClient
+from heroku.client import HerokuAdminClient
 
 import custom_config
 
@@ -15,6 +16,7 @@ import custom_config
 botocore_client = None
 gcp_client = None
 gsuite_client = None
+heroku_client = None
 
 
 def pytest_addoption(parser):
@@ -25,6 +27,10 @@ def pytest_addoption(parser):
     parser.addoption('--gcp-project-id',
                      type=str,
                      help='Set GCP project to test. Required for GCP tests.')
+
+    parser.addoption('--organization',
+                     type=str,
+                     help='Set organization to test. Used for Heroku tests.')
 
     parser.addoption('--debug-calls',
                      action='store_true',
@@ -48,12 +54,14 @@ def pytest_configure(config):
     global botocore_client
     global gcp_client
     global gsuite_client
+    global heroku_client
 
     # monkeypatch cache.set to serialize datetime.datetime's
     patch_cache_set(config)
 
     profiles = config.getoption('--aws-profiles')
     project_id = config.getoption('--gcp-project-id')
+    organization = config.getoption('--organization')
 
     botocore_client = BotocoreClient(
         profiles=profiles,
@@ -65,6 +73,15 @@ def pytest_configure(config):
     gcp_client = GCPClient(
         project_id=project_id,
         cache=config.cache,
+        debug_calls=config.getoption('--debug-calls'),
+        debug_cache=config.getoption('--debug-cache'),
+        offline=config.getoption('--offline'))
+
+    # import pudb; pudb.set_trace()
+    heroku_client = HerokuAdminClient(
+        organization=organization,
+        # cache=config.cache,
+        cache=None,
         debug_calls=config.getoption('--debug-calls'),
         debug_cache=config.getoption('--debug-cache'),
         offline=config.getoption('--offline'))

--- a/conftest.py
+++ b/conftest.py
@@ -28,6 +28,9 @@ def pytest_addoption(parser):
                      type=str,
                      help='Set GCP project to test. Required for GCP tests.')
 
+    # While only used for Heroku at the moment, GitHub tests are soon to be
+    # added, which will also need an "organization" option. Current plan is to
+    # reuse this one.
     parser.addoption('--organization',
                      type=str,
                      help='Set organization to test. Used for Heroku tests.')
@@ -77,7 +80,6 @@ def pytest_configure(config):
         debug_cache=config.getoption('--debug-cache'),
         offline=config.getoption('--offline'))
 
-    # import pudb; pudb.set_trace()
     heroku_client = HerokuAdminClient(
         organization=organization,
         # cache=config.cache,

--- a/heroku/client.py
+++ b/heroku/client.py
@@ -1,0 +1,193 @@
+# from herokuadmintools import verify_access, session
+from herokuadmintools import find_users_missing_2fa, find_affected_apps
+
+
+def cache_key(organization, method, *args, **kwargs):
+    """Returns the fullname (directory and filename) for a Heroku API call.
+
+    >>> cache_key(
+    ... 'organization_name',
+    ... 'method_name',
+    ... 'arg1', 'arg2',
+    ... kwarg1=True,
+    ... )
+    'pytest_heroku:organization_name:method_name:arg1,arg2:kwarg1=True.json'
+    """
+    return ':'.join([
+        'pytest_heroku',
+        str(organization),
+        str(method),
+        ','.join(args),
+        ','.join('{}={}'.format(k, v) for (k, v) in kwargs.items()),
+    ]) + '.json'
+
+
+def get_heroku_resource(organization,
+                        method_name,
+                        call_args,
+                        call_kwargs,
+                        cache=None,
+                        result_from_error=None,
+                        debug_calls=False,
+                        debug_cache=False):
+    """
+    Fetches and return final data
+
+    TODO: more refactoring of herokuadmintools needed, so can:
+        - cache all members
+        - cache all apps of member
+    """
+    if debug_calls:
+        print('calling', method_name, 'on', organization)
+
+    result = None
+    if cache is not None:
+        ckey = cache_key(organization, method_name)
+        result = cache.get(ckey, None)
+
+        if debug_cache and result is not None:
+            print('found cached value for', ckey)
+
+    if result is None:
+        # convert from defaultdict with values as sets
+        users = {k: list(v) for k, v in
+                 find_users_missing_2fa(organization).items()}
+        apps = {k: list(v) for k, v in
+                find_affected_apps(users, organization).items()}
+        result = [{
+            HerokuDataSets.ROLE_USER: users,
+            HerokuDataSets.APP_USER: apps,
+        }]
+
+        if cache is not None:
+            if debug_cache:
+                print('setting cache value for', ckey)
+
+            cache.set(ckey, result)
+
+    return result
+
+
+class HerokuDataSets:
+    # We use an IntEnum so keys can be ordered, which is done deep in some
+    # libraries when we use the enums as dict keys
+    ROLE_USER = 1  # tuple of (role, user)
+    APP_USER = 2   # tuple of (app, user)
+
+
+class HerokuAdminClient:
+
+    # ensure we have access from instance
+    data_set_names = HerokuDataSets
+
+    def __init__(self,
+                 organization,
+                 cache,
+                 debug_calls,
+                 debug_cache,
+                 offline):
+        self.organization = organization
+        self.cache = cache
+
+        self.debug_calls = debug_calls
+        self.debug_cache = debug_cache
+        self.offline = offline
+
+        self.results = []
+
+    def get(self,
+            method_name,
+            call_args,
+            call_kwargs,
+            result_from_error=None,
+            do_not_cache=False):
+
+        if self.offline:
+            self.results = []
+        else:
+            self.results = list(get_heroku_resource(
+                self.organization,
+                method_name,
+                call_args,
+                call_kwargs,
+                cache=self.cache if not do_not_cache else None,
+                result_from_error=result_from_error,
+                debug_calls=self.debug_calls,
+                debug_cache=self.debug_cache))
+
+        return self
+
+    def find_users_missing_2fa(self):
+        return self.extract_key(HerokuDataSets.ROLE_USER, {})
+
+    def find_affected_apps(self):
+        return self.extract_key(HerokuDataSets.APP_USER, {})
+
+    def values(self):
+        """Returns the wrapped value
+
+        >>> c = HerokuAdminClient([None], None, None, None, offline=True)
+        >>> c.results = []
+        >>> c.values()
+        []
+        """
+        return self.results
+
+    def extract_key(self, key, default=None):
+        """
+        From an iterable of dicts returns the value with the given
+        keys discarding other values:
+
+        >>> c = HerokuAdminClient([None], None, None, None, offline=True)
+        >>> c.results = [{'id': 1}, {'id': 2}]
+        >>> c.extract_key('id').results
+        [1, 2]
+
+        When the key does not exist it returns the second arg which defaults to None:
+
+        >>> c = HerokuAdminClient([None], None, None, None, offline=True)
+        >>> c.results = [{'id': 1}, {}]
+        >>> c.extract_key('id').results
+        [1, None]
+
+        But not to primitives:
+
+        >>> c.results = [{'PolicyNames': ['P1', 'P2']}]
+        >>> c.extract_key('PolicyNames').results
+        [['P1', 'P2']]
+        """
+        tmp = []
+        for result in self.results:
+            keyed_result = default
+
+            if key in result:
+                keyed_result = result[key]
+
+            tmp.append(keyed_result)
+
+        self.results = tmp
+        return self
+
+    def flatten(self):
+        """
+        Flattens one level of a nested list:
+
+        >>> c = HerokuAdminClient([None], None, None, None, offline=True)
+        >>> c.results = [['A', 1], ['B']]
+        >>> c.flatten().values()
+        ['A', 1, 'B']
+
+        Only works for a list of lists:
+
+        >>> c.results = [{'A': 1}, {'B': 2}]
+        >>> c.flatten().values()
+        Traceback (most recent call last):
+        ...
+        TypeError: can only concatenate list (not "dict") to list
+        """
+        self.results = sum(self.results, [])
+        return self
+
+    def debug(self):
+        print(self.results)
+        return self

--- a/heroku/resources.py
+++ b/heroku/resources.py
@@ -1,0 +1,32 @@
+
+from conftest import heroku_client
+
+
+def users_no_2fa():
+    """
+    """
+    raw = heroku_client.get(
+        'all', [], {})
+    just_key = raw.extract_key(heroku_client.data_set_names.ROLE_USER, [])
+    datum = just_key.results or [{}]
+    return datum
+    # ##return heroku_client.get(
+    # ##    'all', [], {})\
+    # ##    .extract_key('role_users')\
+    # ##    .flatten()\
+    # ##    .values()
+
+
+def app_users_no_2fa():
+    """
+    """
+    raw = heroku_client.get(
+        'all', [], {})
+    just_key = raw.extract_key(heroku_client.data_set_names.APP_USER, [])
+    datum = just_key.results or [{}]
+    return datum
+    # ##return heroku_client.get(
+    # ##    'all', [], {})\
+    # ##    .extract_key('app_users')\
+    # ##    .flatten()\
+    # ##    .values()

--- a/heroku/test_heroku_2fa.py
+++ b/heroku/test_heroku_2fa.py
@@ -9,41 +9,41 @@
 
 # code for heroku/conftest.py START
 import pytest
-from heroku import resources
+from heroku.resources import users_no_2fa, app_users_no_2fa
 
 
 @pytest.fixture
 def affected_users():
-    roles = resources.users_no_2fa()
-    assert isinstance(roles, type([]))
+    roles = users_no_2fa()
+    # assert isinstance(roles, type([]))
     role = roles[0]
-    assert isinstance(role, type({}))
+    # assert isinstance(role, type({}))
     return role
 
 
 @pytest.fixture
 def affected_apps():
-    apps = resources.app_users_no_2fa()
-    assert isinstance(apps, type([]))
+    apps = app_users_no_2fa()
+    # assert isinstance(apps, type([]))
     app = apps[0]
-    assert isinstance(app, type({}))
+    # assert isinstance(app, type({}))
     return app
 
 
 @pytest.fixture
 def role_user():
-    l = [(role, email) for role, emails in affected_users().items()
-         for email in emails]
-    assert len(l) > 0
-    return l
+    result = [(role, email) for role, emails in affected_users().items()
+              for email in emails]
+    # assert len(result) > 0
+    return result
 
 
 @pytest.fixture
 def app_user():
-    l = [(app, email) for app, emails in affected_apps().items()
-         for email in emails]
-    assert len(l) > 0
-    return l
+    result = [(app, email) for app, emails in affected_apps().items()
+              for email in emails]
+    # assert len(result) > 0
+    return result
 
 
 # ##def pytest_generate_tests(metafunc):

--- a/heroku/test_heroku_2fa.py
+++ b/heroku/test_heroku_2fa.py
@@ -1,0 +1,65 @@
+# TODO: discover why/how the exemptions.py & regressions.py processess screw up
+#       normal pytest operations.  All the fixtures below could/should be in
+#       the heroku/conftest.py file, and no mark.parametrize would be needed on
+#       the actual tests.
+#
+#       With the local conftest.py setup, the tests work, but the warnings are
+#       quite noisy. :/  We're trading off (for the moment at least) test
+#       readability for output readability.
+
+# code for heroku/conftest.py START
+import pytest
+import resources
+
+
+@pytest.fixture
+def affected_users():
+    roles = resources.users_no_2fa()
+    assert isinstance(roles, type([]))
+    role = roles[0]
+    assert isinstance(role, type({}))
+    return role
+
+
+@pytest.fixture
+def affected_apps():
+    apps = resources.app_users_no_2fa()
+    assert isinstance(apps, type([]))
+    app = apps[0]
+    assert isinstance(app, type({}))
+    return app
+
+
+@pytest.fixture
+def role_user():
+    l = [(role, email) for role, emails in affected_users().items()
+         for email in emails]
+    assert len(l) > 0
+    return l
+
+
+@pytest.fixture
+def app_user():
+    l = [(app, email) for app, emails in affected_apps().items()
+         for email in emails]
+    assert len(l) > 0
+    return l
+
+
+# ##def pytest_generate_tests(metafunc):
+# ##    if 'role_user' in metafunc.fixturenames:
+# ##        metafunc.parametrize('role_user', role_user())
+# ##    elif 'app_user' in metafunc.fixturenames:
+# ##        metafunc.parametrize('app_user', app_user())
+
+# code for heroku/conftest.py END
+@pytest.mark.heroku
+@pytest.mark.parametrize('role_user', role_user())
+def test_users_have_2fa_enabled(role_user):
+    assert not role_user
+
+
+@pytest.mark.heroku
+@pytest.mark.parametrize('app_user', app_user())
+def test_no_apps_impacted(app_user):
+    assert not app_user

--- a/heroku/test_heroku_2fa.py
+++ b/heroku/test_heroku_2fa.py
@@ -9,7 +9,7 @@
 
 # code for heroku/conftest.py START
 import pytest
-import resources
+from heroku import resources
 
 
 @pytest.fixture

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pytest-json==0.4.0
 pytest-metadata==1.5.1
 pytest==3.3.2
 python-dateutil==2.6.1
+git+https://github.com/hwine/python-herokuadmintools.git#egg=herokuadmintools


### PR DESCRIPTION
- Now follows pytest-services conventions
- doctests pass
- functional tests pass

Caching is not working. Phase 2 ;)

execution with valid org (failure expected):
```
$ pytest --tb line --organization mozillacorporation heroku/
===================================================================================================================== test session starts ======================================================================================================================
platform linux -- Python 3.6.4, pytest-3.3.2, py-1.5.3, pluggy-0.6.0
metadata: {'Python': '3.6.4', 'Platform': 'Linux-4.4.0-43-Microsoft-x86_64-with-debian-stretch-sid', 'Packages': {'pytest': '3.3.2', 'py': '1.5.3', 'pluggy': '0.6.0'}, 'Plugins': {'pudb': '0.6', 'metadata': '1.5.1', 'json': '0.4.0', 'html': '1.16.1', 'cov': '2.5.1'}}
rootdir: /home/hwine/repos/pytest-services, inifile:
plugins: pudb-0.6, metadata-1.5.1, json-0.4.0, html-1.16.1, cov-2.5.1
collected 14 items

heroku/test_heroku_2fa.py FFFFFFFFFFFFFF                                                                                                                                                                                                                 [100%]

=========================================================================================================================== FAILURES ===========================================================================================================================
/home/hwine/repos/pytest-services/heroku/test_heroku_2fa.py:59: AssertionError: assert not ('collaborator', 'rnorthey@mozilla.com')
/home/hwine/repos/pytest-services/heroku/test_heroku_2fa.py:59: AssertionError: assert not ('collaborator', 'aturon@mozilla.com')
/home/hwine/repos/pytest-services/heroku/test_heroku_2fa.py:59: AssertionError: assert not ('collaborator', 'mbebenita@mozilla.com')
/home/hwine/repos/pytest-services/heroku/test_heroku_2fa.py:59: AssertionError: assert not ('collaborator', 'kyee@mozilla.com')
/home/hwine/repos/pytest-services/heroku/test_heroku_2fa.py:59: AssertionError: assert not ('collaborator', 'sean@seantheprogrammer.com')
/home/hwine/repos/pytest-services/heroku/test_heroku_2fa.py:59: AssertionError: assert not ('collaborator', 'reuben@mozilla.com')
/home/hwine/repos/pytest-services/heroku/test_heroku_2fa.py:65: AssertionError: assert not ('rustconf', 'aturon@mozilla.com')
/home/hwine/repos/pytest-services/heroku/test_heroku_2fa.py:65: AssertionError: assert not ('webxr-agent', 'kyee@mozilla.com')
/home/hwine/repos/pytest-services/heroku/test_heroku_2fa.py:65: AssertionError: assert not ('webassembly-studio-clang', 'mbebenita@mozilla.com')
/home/hwine/repos/pytest-services/heroku/test_heroku_2fa.py:65: AssertionError: assert not ('wasmexplorer-service', 'mbebenita@mozilla.com')
/home/hwine/repos/pytest-services/heroku/test_heroku_2fa.py:65: AssertionError: assert not ('deepspeech-scriptworker', 'reuben@mozilla.com')
/home/hwine/repos/pytest-services/heroku/test_heroku_2fa.py:65: AssertionError: assert not ('mozilla-pontoon', 'rnorthey@mozilla.com')
/home/hwine/repos/pytest-services/heroku/test_heroku_2fa.py:65: AssertionError: assert not ('mozilla-pontoon-staging', 'rnorthey@mozilla.com')
/home/hwine/repos/pytest-services/heroku/test_heroku_2fa.py:65: AssertionError: assert not ('crates-io', 'sean@seantheprogrammer.com')
================================================================================================================== 14 failed in 2.21 seconds ===================================================================================================================
1 [hwine@hwine-surface pytest-services (venv)]
```

execution with invalid org (poor fred):
```
$ pytest --tb line --organization fred heroku/
===================================================================================================================== test session starts ======================================================================================================================
platform linux -- Python 3.6.4, pytest-3.3.2, py-1.5.3, pluggy-0.6.0
metadata: {'Python': '3.6.4', 'Platform': 'Linux-4.4.0-43-Microsoft-x86_64-with-debian-stretch-sid', 'Packages': {'pytest': '3.3.2', 'py': '1.5.3', 'pluggy': '0.6.0'}, 'Plugins': {'pudb': '0.6', 'metadata': '1.5.1', 'json': '0.4.0', 'html': '1.16.1', 'cov': '2.5.1'}}
rootdir: /home/hwine/repos/pytest-services, inifile:
plugins: pudb-0.6, metadata-1.5.1, json-0.4.0, html-1.16.1, cov-2.5.1
collected 0 items / 1 errors

============================================================================================================================ ERRORS ============================================================================================================================
__________________________________________________________________________________________________________ ERROR collecting heroku/test_heroku_2fa.py __________________________________________________________________________________________________________
heroku/test_heroku_2fa.py:57: in <module>
    @pytest.mark.parametrize('role_user', role_user())
heroku/test_heroku_2fa.py:37: in role_user
    assert len(l) > 0
E   assert 0 > 0
E    +  where 0 = len([])
----------------------------------------------------------------------------------------------------------------------- Captured stderr ------------------------------------------------------------------------------------------------------------------------
Failure communicating with Heroku
Traceback (most recent call last):
  File "/home/hwine/repos/pytest-services/venv/lib/python3.6/site-packages/herokuadmintools/__init__.py", line 57, in find_users_missing_2fa
    org_users = fetch_api_json(get_org_member_url(org))
  File "/home/hwine/repos/pytest-services/venv/lib/python3.6/site-packages/herokuadmintools/__init__.py", line 90, in fetch_api_json
    response.raise_for_status()
  File "/home/hwine/repos/pytest-services/venv/lib/python3.6/site-packages/requests/models.py", line 935, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://api.heroku.com/organizations/fred/members
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
=================================================================================================================== 1 error in 0.99 seconds ====================================================================================================================
```
