### PR TITLE
Change linter/formatter to black

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ install:
   - make install
 
 script:
-  - make doctest coverage flake8
+  - make doctest coverage black

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ coverage: check_venv
 flake8: check_venv
 	flake8 --max-line-length 120 $(shell git ls-files | grep \.py$$)
 
+black: check_venv
+	black --check $(shell git ls-files | grep \.py$$)
+
 install: venv
 	( . venv/bin/activate && pip install -r requirements.txt )
 

--- a/aws/autoscaling/resources.py
+++ b/aws/autoscaling/resources.py
@@ -5,8 +5,9 @@ def autoscaling_launch_configurations():
     """
     http://botocore.readthedocs.io/en/latest/reference/services/autoscaling.html#AutoScaling.Client.describe_launch_configurations
     """
-    return botocore_client.get(
-        'autoscaling', 'describe_launch_configurations', [], {})\
-        .extract_key('LaunchConfigurations')\
-        .flatten()\
+    return (
+        botocore_client.get("autoscaling", "describe_launch_configurations", [], {})
+        .extract_key("LaunchConfigurations")
+        .flatten()
         .values()
+    )

--- a/aws/cloudtrail/resources.py
+++ b/aws/cloudtrail/resources.py
@@ -3,16 +3,17 @@ from conftest import botocore_client
 
 def cloudtrails():
     "https://botocore.readthedocs.io/en/latest/reference/services/cloudtrail.html#CloudTrail.Client.describe_trails"
-    trails = botocore_client.get(
-        'cloudtrail', 'describe_trails', [], {})\
-        .extract_key('trailList')\
-        .flatten()\
+    trails = (
+        botocore_client.get("cloudtrail", "describe_trails", [], {})
+        .extract_key("trailList")
+        .flatten()
         .values()
+    )
 
     # This is due to the fact that if you have a multi region cloudtrail, it will be included for each region.
     unique_trails = []
     for trail in trails:
-        if not any(t for t in unique_trails if t['TrailARN'] == trail['TrailARN']):
+        if not any(t for t in unique_trails if t["TrailARN"] == trail["TrailARN"]):
             unique_trails.append(trail)
 
     return unique_trails

--- a/aws/cloudtrail/test_cloudtrail_enabled_in_all_regions.py
+++ b/aws/cloudtrail/test_cloudtrail_enabled_in_all_regions.py
@@ -11,13 +11,13 @@ def all_cloudtrails():
 
 
 @pytest.mark.cloudtrail
-@pytest.mark.parametrize('aws_region',
-                         botocore_client.get_regions())
+@pytest.mark.parametrize("aws_region", botocore_client.get_regions())
 def test_cloudtrail_enabled_in_all_regions(aws_region, all_cloudtrails):
     """
     Tests that all regions have an associated cloudtrail or that there is a cloudtrail for all regions.
     """
     assert any(
-        trail for trail in all_cloudtrails
-        if trail['HomeRegion'] == aws_region or trail['IsMultiRegionTrail']
+        trail
+        for trail in all_cloudtrails
+        if trail["HomeRegion"] == aws_region or trail["IsMultiRegionTrail"]
     )

--- a/aws/cloudtrail/test_cloudtrail_log_validation_enabled.py
+++ b/aws/cloudtrail/test_cloudtrail_log_validation_enabled.py
@@ -4,11 +4,9 @@ from aws.cloudtrail.resources import cloudtrails
 
 
 @pytest.mark.cloudtrail
-@pytest.mark.parametrize('cloudtrail',
-                         cloudtrails(),
-                         ids=lambda trail: trail['Name'])
+@pytest.mark.parametrize("cloudtrail", cloudtrails(), ids=lambda trail: trail["Name"])
 def test_cloudtrail_log_validation_enabled(cloudtrail):
     """
     Tests that all Cloudtrails have log validation enabled.
     """
-    assert cloudtrail['LogFileValidationEnabled']
+    assert cloudtrail["LogFileValidationEnabled"]

--- a/aws/ec2/helpers.py
+++ b/aws/ec2/helpers.py
@@ -15,16 +15,16 @@ def ip_permission_opens_all_ports(ipp):
     >>> ip_permission_opens_all_ports({'ToPort': -1})
     False
     """
-    if 'FromPort' not in ipp or 'ToPort' not in ipp:
+    if "FromPort" not in ipp or "ToPort" not in ipp:
         return False
 
-    from_port, to_port = ipp['FromPort'], ipp['ToPort']
+    from_port, to_port = ipp["FromPort"], ipp["ToPort"]
 
     # -1 indicates all ICMP/ICMPv6 codes
     if from_port == -1 or to_port == -1:
         return True
 
-    if ipp['FromPort'] <= 1 and ipp['ToPort'] >= 65535:
+    if ipp["FromPort"] <= 1 and ipp["ToPort"] >= 65535:
         return True
 
     return False
@@ -48,12 +48,12 @@ def ip_permission_cidr_allows_all_ips(ipp):
     >>> ip_permission_cidr_allows_all_ips({})
     False
     """
-    for ip_range in ipp.get('IpRanges', []):
-        if ip_range.get('CidrIp', '') == '0.0.0.0/0':
+    for ip_range in ipp.get("IpRanges", []):
+        if ip_range.get("CidrIp", "") == "0.0.0.0/0":
             return True
 
-    for ip_range in ipp.get('Ipv6Ranges', []):
-        if ip_range.get('CidrIpv6', '') == '::/0':
+    for ip_range in ipp.get("Ipv6Ranges", []):
+        if ip_range.get("CidrIpv6", "") == "::/0":
             return True
 
     return False
@@ -73,8 +73,8 @@ def ip_permission_grants_access_to_group_with_id(ipp, security_group_id):
     >>> ip_permission_grants_access_to_group_with_id({}, 'test-sgid')
     False
     """
-    for user_id_group_pair in ipp.get('UserIdGroupPairs', []):
-        if user_id_group_pair.get('GroupId', None) == security_group_id:
+    for user_id_group_pair in ipp.get("UserIdGroupPairs", []):
+        if user_id_group_pair.get("GroupId", None) == security_group_id:
             return True
 
     return False
@@ -96,11 +96,11 @@ def ec2_security_group_opens_all_ports(ec2_security_group):
     >>> ec2_security_group_opens_all_ports({})
     False
     """
-    if 'IpPermissions' not in ec2_security_group:
+    if "IpPermissions" not in ec2_security_group:
         return False
 
-    for ipp in ec2_security_group['IpPermissions']:
-        if 'IpProtocol' in ipp and ipp['IpProtocol'] == "icmp":
+    for ipp in ec2_security_group["IpPermissions"]:
+        if "IpProtocol" in ipp and ipp["IpProtocol"] == "icmp":
             continue
         if ip_permission_opens_all_ports(ipp):
             return True
@@ -146,19 +146,20 @@ def ec2_security_group_opens_all_ports_to_self(ec2_security_group):
     >>> ec2_security_group_opens_all_ports_to_self([])
     False
     """
-    if 'GroupId' not in ec2_security_group:
+    if "GroupId" not in ec2_security_group:
         return False
 
-    self_group_id = ec2_security_group['GroupId']
+    self_group_id = ec2_security_group["GroupId"]
 
-    if 'IpPermissions' not in ec2_security_group:
+    if "IpPermissions" not in ec2_security_group:
         return False
 
-    for ipp in ec2_security_group['IpPermissions']:
-        if 'IpProtocol' in ipp and ipp['IpProtocol'] == "icmp":
+    for ipp in ec2_security_group["IpPermissions"]:
+        if "IpProtocol" in ipp and ipp["IpProtocol"] == "icmp":
             continue
-        if ip_permission_opens_all_ports(ipp) and \
-                ip_permission_grants_access_to_group_with_id(ipp, self_group_id):
+        if ip_permission_opens_all_ports(
+            ipp
+        ) and ip_permission_grants_access_to_group_with_id(ipp, self_group_id):
             return True
 
     return False
@@ -190,19 +191,23 @@ def ec2_security_group_opens_all_ports_to_all(ec2_security_group):
     >>> ec2_security_group_opens_all_ports_to_all([])
     False
     """
-    if 'IpPermissions' not in ec2_security_group:
+    if "IpPermissions" not in ec2_security_group:
         return False
 
-    for ipp in ec2_security_group['IpPermissions']:
-        if 'IpProtocol' in ipp and ipp['IpProtocol'] == "icmp":
+    for ipp in ec2_security_group["IpPermissions"]:
+        if "IpProtocol" in ipp and ipp["IpProtocol"] == "icmp":
             continue
-        if ip_permission_opens_all_ports(ipp) and ip_permission_cidr_allows_all_ips(ipp):
+        if ip_permission_opens_all_ports(ipp) and ip_permission_cidr_allows_all_ips(
+            ipp
+        ):
             return True
 
     return False
 
 
-def ec2_security_group_opens_specific_ports_to_all(ec2_security_group, whitelisted_ports=None):
+def ec2_security_group_opens_specific_ports_to_all(
+    ec2_security_group, whitelisted_ports=None
+):
     """
     Returns True if an ec2 security group includes a permission
     allowing all IPs inbound access on specific unsafe ports and False
@@ -231,18 +236,18 @@ def ec2_security_group_opens_specific_ports_to_all(ec2_security_group, whitelist
     if whitelisted_ports is None:
         whitelisted_ports = []
 
-    if 'IpPermissions' not in ec2_security_group:
+    if "IpPermissions" not in ec2_security_group:
         return False
 
-    for ipp in ec2_security_group['IpPermissions']:
-        if 'IpProtocol' in ipp and ipp['IpProtocol'] == "icmp":
+    for ipp in ec2_security_group["IpPermissions"]:
+        if "IpProtocol" in ipp and ipp["IpProtocol"] == "icmp":
             continue
 
         if ip_permission_cidr_allows_all_ips(ipp):
-            if 'FromPort' not in ipp or 'ToPort' not in ipp:
+            if "FromPort" not in ipp or "ToPort" not in ipp:
                 continue
 
-            from_port, to_port = ipp['FromPort'], ipp['ToPort']
+            from_port, to_port = ipp["FromPort"], ipp["ToPort"]
             if from_port == to_port and from_port in [80, 443]:
                 continue
 
@@ -256,12 +261,12 @@ def ec2_security_group_opens_specific_ports_to_all(ec2_security_group, whitelist
 
 def ec2_instance_test_id(ec2_instance):
     """A getter fn for test ids for EC2 instances"""
-    return '{0[InstanceId]}'.format(ec2_instance)
+    return "{0[InstanceId]}".format(ec2_instance)
 
 
 def ec2_security_group_test_id(ec2_security_group):
     """A getter fn for test ids for EC2 security groups"""
-    return '{0[GroupId]} {0[GroupName]}'.format(ec2_security_group)
+    return "{0[GroupId]} {0[GroupName]}".format(ec2_security_group)
 
 
 def is_ebs_volume_encrypted(ebs):
@@ -285,7 +290,7 @@ def is_ebs_volume_encrypted(ebs):
     ...
     TypeError: 'NoneType' object is not subscriptable
     """
-    return ebs['Encrypted']
+    return ebs["Encrypted"]
 
 
 def ec2_instance_missing_tag_names(ec2_instance, required_tag_names):
@@ -298,6 +303,6 @@ def ec2_instance_missing_tag_names(ec2_instance, required_tag_names):
     ... 'InstanceId': 'iid', 'Tags': [{'Key': 'Bar'}]}, frozenset(['Name']))
     frozenset({'Name'})
     """
-    tags = ec2_instance.get('Tags', [])
-    instance_tag_names = set(tag['Key'] for tag in tags if 'Key' in tag)
+    tags = ec2_instance.get("Tags", [])
+    instance_tag_names = set(tag["Key"] for tag in tags if "Key" in tag)
     return required_tag_names - instance_tag_names

--- a/aws/ec2/resources.py
+++ b/aws/ec2/resources.py
@@ -4,10 +4,7 @@ from conftest import botocore_client
 
 from aws.autoscaling.resources import autoscaling_launch_configurations
 from aws.elasticache.resources import elasticache_clusters
-from aws.elb.resources import (
-    elbs,
-    elbs_v2,
-)
+from aws.elb.resources import elbs, elbs_v2
 from aws.rds.resources import rds_db_instances
 from aws.redshift.resources import redshift_clusters
 from aws.elasticsearch.resources import elasticsearch_domains
@@ -16,53 +13,63 @@ from aws.elasticsearch.resources import elasticsearch_domains
 def ec2_instances():
     "http://botocore.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.describe_instances"
     # Note: extracting Reservations.Instances drops EC2-Classic Groups at Reservations.Groups
-    return botocore_client.get(
-            'ec2',
-            'describe_instances',
+    return (
+        botocore_client.get(
+            "ec2",
+            "describe_instances",
             [],
-            {'Filters': [{'Name': 'instance-state-name', 'Values': ['pending', 'running']}]}
-        )\
-        .extract_key('Reservations')\
-        .flatten()\
-        .extract_key('Instances')\
-        .flatten()\
+            {
+                "Filters": [
+                    {"Name": "instance-state-name", "Values": ["pending", "running"]}
+                ]
+            },
+        )
+        .extract_key("Reservations")
+        .flatten()
+        .extract_key("Instances")
+        .flatten()
         .values()
+    )
 
 
 def ec2_security_groups():
     "http://botocore.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.describe_security_groups"
-    return botocore_client.get(
-        'ec2', 'describe_security_groups', [], {})\
-        .extract_key('SecurityGroups')\
-        .flatten()\
+    return (
+        botocore_client.get("ec2", "describe_security_groups", [], {})
+        .extract_key("SecurityGroups")
+        .flatten()
         .values()
+    )
 
 
 def ec2_ebs_volumes():
     "http://botocore.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.describe_volumes"
-    return botocore_client.get(
-        'ec2', 'describe_volumes', [], {})\
-        .extract_key('Volumes')\
-        .flatten()\
+    return (
+        botocore_client.get("ec2", "describe_volumes", [], {})
+        .extract_key("Volumes")
+        .flatten()
         .values()
+    )
 
 
 def ec2_flow_logs():
     "https://botocore.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.describe_flow_logs"
-    return botocore_client.get(
-        'ec2', 'describe_flow_logs', [], {})\
-        .extract_key('FlowLogs')\
-        .flatten()\
+    return (
+        botocore_client.get("ec2", "describe_flow_logs", [], {})
+        .extract_key("FlowLogs")
+        .flatten()
         .values()
+    )
 
 
 def ec2_vpcs():
     "https://botocore.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.describe_vpcs"
-    return botocore_client.get(
-        'ec2', 'describe_vpcs', [], {})\
-        .extract_key('Vpcs')\
-        .flatten()\
+    return (
+        botocore_client.get("ec2", "describe_vpcs", [], {})
+        .extract_key("Vpcs")
+        .flatten()
         .values()
+    )
 
 
 def ec2_security_groups_with_in_use_flag():
@@ -84,35 +91,41 @@ def ec2_security_groups_with_in_use_flag():
     # These resources have their security groups under 'SecurityGroups'.
     # Most of these are a list of dictionaries which include either SecurityGroupId
     # or GroupId, but some have just a list of group ids.
-    resources = sum([
-        ec2_instances(),
-        elbs(),
-        elbs_v2(),
-        elasticache_clusters(),
-        autoscaling_launch_configurations()
-    ], [])
+    resources = sum(
+        [
+            ec2_instances(),
+            elbs(),
+            elbs_v2(),
+            elasticache_clusters(),
+            autoscaling_launch_configurations(),
+        ],
+        [],
+    )
     for resource in resources:
-        for attached_sec_group in resource.get('SecurityGroups', []):
+        for attached_sec_group in resource.get("SecurityGroups", []):
             if isinstance(attached_sec_group, dict):
-                for key in ['SecurityGroupId', 'GroupId']:
+                for key in ["SecurityGroupId", "GroupId"]:
                     if key in attached_sec_group:
                         in_use_sec_group_ids[attached_sec_group[key]] += 1
             elif isinstance(attached_sec_group, str):
                 in_use_sec_group_ids[attached_sec_group] += 1
             else:
-                raise Exception("Got security group value with a type of %s" % type(attached_sec_group))
+                raise Exception(
+                    "Got security group value with a type of %s"
+                    % type(attached_sec_group)
+                )
 
     # These resources have two types of security groups, therefore
     # the Vpc ones are namespaced under "VpcSecurityGroups"
     vpc_namespaced_resources = sum([rds_db_instances(), redshift_clusters()], [])
     for resource in vpc_namespaced_resources:
-        for attached_sec_group in resource.get('VpcSecurityGroups', []):
-            in_use_sec_group_ids[attached_sec_group['VpcSecurityGroupId']] += 1
+        for attached_sec_group in resource.get("VpcSecurityGroups", []):
+            in_use_sec_group_ids[attached_sec_group["VpcSecurityGroupId"]] += 1
 
     # ElasticSearchService does it a little differently
     for domain in elasticsearch_domains():
-        if 'VPCOptions' in domain:
-            for attached_sec_group in domain['VPCOptions']['SecurityGroupIds']:
+        if "VPCOptions" in domain:
+            for attached_sec_group in domain["VPCOptions"]["SecurityGroupIds"]:
                 in_use_sec_group_ids[attached_sec_group] += 1
 
     for sec_group in sec_groups:

--- a/aws/ec2/test_ec2_ebs_volume_encrypted.py
+++ b/aws/ec2/test_ec2_ebs_volume_encrypted.py
@@ -6,9 +6,7 @@ from aws.ec2.helpers import is_ebs_volume_encrypted
 
 @pytest.mark.ec2
 @pytest.mark.parametrize(
-    'ec2_ebs_volume',
-    ec2_ebs_volumes(),
-    ids=lambda ebs: ebs['VolumeId'],
+    "ec2_ebs_volume", ec2_ebs_volumes(), ids=lambda ebs: ebs["VolumeId"]
 )
 def test_ec2_ebs_volume_encrypted(ec2_ebs_volume):
     assert is_ebs_volume_encrypted(ec2_ebs_volume)

--- a/aws/ec2/test_ec2_instance_has_required_tags.py
+++ b/aws/ec2/test_ec2_instance_has_required_tags.py
@@ -1,9 +1,6 @@
 import pytest
 
-from aws.ec2.helpers import (
-    ec2_instance_test_id,
-    ec2_instance_missing_tag_names
-)
+from aws.ec2.helpers import ec2_instance_test_id, ec2_instance_missing_tag_names
 from aws.ec2.resources import ec2_instances
 
 
@@ -13,10 +10,7 @@ def required_tag_names(pytestconfig):
 
 
 @pytest.mark.ec2
-@pytest.mark.parametrize(
-    'ec2_instance',
-    ec2_instances(),
-    ids=ec2_instance_test_id)
+@pytest.mark.parametrize("ec2_instance", ec2_instances(), ids=ec2_instance_test_id)
 def test_ec2_instance_has_required_tags(ec2_instance, required_tag_names):
     """
     Checks that all EC2 instances have the tags with the required names.
@@ -24,7 +18,10 @@ def test_ec2_instance_has_required_tags(ec2_instance, required_tag_names):
     Does not check tag values.
     """
     if len(required_tag_names) == 0:
-        pytest.skip('No required tag names were provided')
+        pytest.skip("No required tag names were provided")
     missing_tag_names = ec2_instance_missing_tag_names(ec2_instance, required_tag_names)
-    assert not missing_tag_names, \
-        "EC2 Instance {0[InstanceId]} missing required tags {1!r}".format(ec2_instance, missing_tag_names)
+    assert (
+        not missing_tag_names
+    ), "EC2 Instance {0[InstanceId]} missing required tags {1!r}".format(
+        ec2_instance, missing_tag_names
+    )

--- a/aws/ec2/test_ec2_security_group_in_use.py
+++ b/aws/ec2/test_ec2_security_group_in_use.py
@@ -5,15 +5,21 @@ from aws.ec2.resources import ec2_security_groups_with_in_use_flag
 
 
 @pytest.mark.ec2
-@pytest.mark.rationale("""
+@pytest.mark.rationale(
+    """
 Having unused security groups adds cruft in an AWS account, increases the
 likelihood of a mistake, and makes security testing harder.
-""")
-@pytest.mark.parametrize('ec2_security_group',
-                         ec2_security_groups_with_in_use_flag(),
-                         ids=ec2_security_group_test_id)
+"""
+)
+@pytest.mark.parametrize(
+    "ec2_security_group",
+    ec2_security_groups_with_in_use_flag(),
+    ids=ec2_security_group_test_id,
+)
 def test_ec2_security_group_in_use(ec2_security_group):
     """Checks to make sure that the security group
     is currently attached to at least one EC2 instance
     """
-    assert ec2_security_group["InUse"], "Security group is not currently attached to any instance."
+    assert ec2_security_group[
+        "InUse"
+    ], "Security group is not currently attached to any instance."

--- a/aws/ec2/test_ec2_security_group_opens_all_ports.py
+++ b/aws/ec2/test_ec2_security_group_opens_all_ports.py
@@ -4,15 +4,15 @@ from aws.ec2.helpers import (
     ec2_security_group_test_id,
     ec2_security_group_opens_all_ports,
 )
-from aws.ec2.resources import (
-    ec2_security_groups_with_in_use_flag,
-)
+from aws.ec2.resources import ec2_security_groups_with_in_use_flag
 
 
 @pytest.mark.ec2
-@pytest.mark.parametrize('ec2_security_group',
-                         ec2_security_groups_with_in_use_flag(),
-                         ids=ec2_security_group_test_id)
+@pytest.mark.parametrize(
+    "ec2_security_group",
+    ec2_security_groups_with_in_use_flag(),
+    ids=ec2_security_group_test_id,
+)
 def test_ec2_security_group_opens_all_ports(ec2_security_group):
     """Checks whether an EC2 security group includes a permission
     allowing inbound access on all ports.

--- a/aws/ec2/test_ec2_security_group_opens_all_ports_to_all.py
+++ b/aws/ec2/test_ec2_security_group_opens_all_ports_to_all.py
@@ -6,15 +6,15 @@ from aws.ec2.helpers import (
     ec2_security_group_test_id,
     ec2_security_group_opens_all_ports_to_all,
 )
-from aws.ec2.resources import (
-    ec2_security_groups_with_in_use_flag,
-)
+from aws.ec2.resources import ec2_security_groups_with_in_use_flag
 
 
 @pytest.mark.ec2
-@pytest.mark.parametrize('ec2_security_group',
-                         ec2_security_groups_with_in_use_flag(),
-                         ids=ec2_security_group_test_id)
+@pytest.mark.parametrize(
+    "ec2_security_group",
+    ec2_security_groups_with_in_use_flag(),
+    ids=ec2_security_group_test_id,
+)
 def test_ec2_security_group_opens_all_ports_to_all(ec2_security_group):
     """Checks whether an EC2 security group includes a permission
     allowing inbound access to all IPs on all ports."""

--- a/aws/ec2/test_ec2_security_group_opens_all_ports_to_self.py
+++ b/aws/ec2/test_ec2_security_group_opens_all_ports_to_self.py
@@ -6,15 +6,15 @@ from aws.ec2.helpers import (
     ec2_security_group_test_id,
     ec2_security_group_opens_all_ports_to_self,
 )
-from aws.ec2.resources import (
-    ec2_security_groups_with_in_use_flag,
-)
+from aws.ec2.resources import ec2_security_groups_with_in_use_flag
 
 
 @pytest.mark.ec2
-@pytest.mark.parametrize('ec2_security_group',
-                         ec2_security_groups_with_in_use_flag(),
-                         ids=ec2_security_group_test_id)
+@pytest.mark.parametrize(
+    "ec2_security_group",
+    ec2_security_groups_with_in_use_flag(),
+    ids=ec2_security_group_test_id,
+)
 def test_ec2_security_group_opens_all_ports_to_self(ec2_security_group):
     """Checks whether an EC2 security group includes a permission
     allowing unrestricted inbound access within the security group."""

--- a/aws/ec2/test_ec2_security_group_opens_specific_ports_to_all.py
+++ b/aws/ec2/test_ec2_security_group_opens_specific_ports_to_all.py
@@ -4,22 +4,22 @@ from aws.ec2.helpers import (
     ec2_security_group_test_id,
     ec2_security_group_opens_specific_ports_to_all,
 )
-from aws.ec2.resources import (
-    ec2_security_groups_with_in_use_flag,
-)
+from aws.ec2.resources import ec2_security_groups_with_in_use_flag
 
 
 @pytest.mark.ec2
-@pytest.mark.parametrize('ec2_security_group',
-                         ec2_security_groups_with_in_use_flag(),
-                         ids=ec2_security_group_test_id)
+@pytest.mark.parametrize(
+    "ec2_security_group",
+    ec2_security_groups_with_in_use_flag(),
+    ids=ec2_security_group_test_id,
+)
 def test_ec2_security_group_opens_specific_ports_to_all(ec2_security_group, aws_config):
     """Checks whether an EC2 security group includes a permission allowing
     inbound access on specific ports. Excluded ports are 80 and 443.
     """
     if ec2_security_group["InUse"]:
         whitelisted_ports = aws_config.get_whitelisted_ports(
-                ec2_security_group_test_id(ec2_security_group)
+            ec2_security_group_test_id(ec2_security_group)
         )
         assert not ec2_security_group_opens_specific_ports_to_all(
             ec2_security_group, whitelisted_ports

--- a/aws/ec2/test_ec2_vpc_flow_log_enabled.py
+++ b/aws/ec2/test_ec2_vpc_flow_log_enabled.py
@@ -1,9 +1,6 @@
 import pytest
 
-from aws.ec2.resources import (
-    ec2_flow_logs,
-    ec2_vpcs
-)
+from aws.ec2.resources import ec2_flow_logs, ec2_vpcs
 
 
 @pytest.fixture
@@ -12,9 +9,13 @@ def all_flow_logs():
 
 
 @pytest.mark.ec2
-@pytest.mark.parametrize('ec2_vpc', ec2_vpcs(), ids=lambda vpc: vpc['VpcId'])
+@pytest.mark.parametrize("ec2_vpc", ec2_vpcs(), ids=lambda vpc: vpc["VpcId"])
 def test_ec2_vpc_flow_log_enabled(ec2_vpc, all_flow_logs):
     """
     Checks that each VPC has VPC Flow Logs enabled.
     """
-    assert any(flow_log for flow_log in all_flow_logs if flow_log['ResourceId'] == ec2_vpc['VpcId'])
+    assert any(
+        flow_log
+        for flow_log in all_flow_logs
+        if flow_log["ResourceId"] == ec2_vpc["VpcId"]
+    )

--- a/aws/elasticache/resources.py
+++ b/aws/elasticache/resources.py
@@ -5,8 +5,9 @@ def elasticache_clusters():
     """
     http://botocore.readthedocs.io/en/latest/reference/services/elasticache.html#ElastiCache.Client.describe_cache_clusters
     """
-    return botocore_client.get(
-        'elasticache', 'describe_cache_clusters', [], {})\
-        .extract_key('CacheClusters')\
-        .flatten()\
+    return (
+        botocore_client.get("elasticache", "describe_cache_clusters", [], {})
+        .extract_key("CacheClusters")
+        .flatten()
         .values()
+    )

--- a/aws/elasticsearch/resources.py
+++ b/aws/elasticsearch/resources.py
@@ -9,20 +9,26 @@ def elasticsearch_domains():
     domains_list = list_elasticsearch_domains()
     domains = []
     for i in range(0, len(domains_list), 5):
-        domains += botocore_client.get(
-            'es', 'describe_elasticsearch_domains', [], {'DomainNames': domains_list[i:i+5]})\
-            .extract_key('DomainStatusList')\
-            .flatten()\
+        domains += (
+            botocore_client.get(
+                "es",
+                "describe_elasticsearch_domains",
+                [],
+                {"DomainNames": domains_list[i : i + 5]},
+            )
+            .extract_key("DomainStatusList")
+            .flatten()
             .values()
+        )
     return domains
 
 
 def list_elasticsearch_domains():
     "http://botocore.readthedocs.io/en/latest/reference/services/es.html#ElasticsearchService.Client.list_domain_names"
     return [
-        domain['DomainName'] for domain in
-        botocore_client.get('es', 'list_domain_names', [], {})
-        .extract_key('DomainNames')
+        domain["DomainName"]
+        for domain in botocore_client.get("es", "list_domain_names", [], {})
+        .extract_key("DomainNames")
         .flatten()
         .values()
     ]

--- a/aws/elasticsearch/test_elasticsearch_domains_have_logging_enabled.py
+++ b/aws/elasticsearch/test_elasticsearch_domains_have_logging_enabled.py
@@ -5,16 +5,18 @@ from aws.elasticsearch.resources import elasticsearch_domains
 
 @pytest.mark.elasticsearch
 @pytest.mark.parametrize(
-        'es_domain',
-        elasticsearch_domains(),
-        ids=lambda es_domain: es_domain['ARN'])
+    "es_domain", elasticsearch_domains(), ids=lambda es_domain: es_domain["ARN"]
+)
 def test_elasticsearch_domains_have_logging_enabled(es_domain):
     """
     Tests whether an elasticsearch domain has logging enabled.
     """
-    assert es_domain.get('LogPublishingOption') is not None, \
-        "Logging is disabled for {}".format(es_domain["DomainName"])
-    assert es_domain['LogPublishingOptions']['INDEX_SLOW_LOGS']['Enabled'], \
-        "Index Slow Logs are disabled for {}".format(es_domain["DomainName"])
-    assert es_domain['LogPublishingOptions']['SEARCH_SLOW_LOGS']['Enabled'], \
-        "Search Slow Logs are disabled for {}".format(es_domain["DomainName"])
+    assert (
+        es_domain.get("LogPublishingOption") is not None
+    ), "Logging is disabled for {}".format(es_domain["DomainName"])
+    assert es_domain["LogPublishingOptions"]["INDEX_SLOW_LOGS"][
+        "Enabled"
+    ], "Index Slow Logs are disabled for {}".format(es_domain["DomainName"])
+    assert es_domain["LogPublishingOptions"]["SEARCH_SLOW_LOGS"][
+        "Enabled"
+    ], "Search Slow Logs are disabled for {}".format(es_domain["DomainName"])

--- a/aws/elb/resources.py
+++ b/aws/elb/resources.py
@@ -5,19 +5,21 @@ def elbs():
     """
     http://botocore.readthedocs.io/en/latest/reference/services/elb.html#ElasticLoadBalancing.Client.describe_load_balancers
     """
-    return botocore_client.get(
-        'elb', 'describe_load_balancers', [], {})\
-        .extract_key('LoadBalancerDescriptions')\
-        .flatten()\
+    return (
+        botocore_client.get("elb", "describe_load_balancers", [], {})
+        .extract_key("LoadBalancerDescriptions")
+        .flatten()
         .values()
+    )
 
 
 def elbs_v2():
     """
     http://botocore.readthedocs.io/en/latest/reference/services/elbv2.html#ElasticLoadBalancingv2.Client.describe_load_balancers
     """
-    return botocore_client.get(
-        'elbv2', 'describe_load_balancers', [], {})\
-        .extract_key('LoadBalancers')\
-        .flatten()\
+    return (
+        botocore_client.get("elbv2", "describe_load_balancers", [], {})
+        .extract_key("LoadBalancers")
+        .flatten()
         .values()
+    )

--- a/aws/iam/helpers.py
+++ b/aws/iam/helpers.py
@@ -78,27 +78,41 @@ def user_is_inactive(iam_user, no_activity_since, created_after):
     True
     """
 
-    if parse(iam_user['user_creation_time']) > created_after:
+    if parse(iam_user["user_creation_time"]) > created_after:
         return False
 
-    if is_credential_active(iam_user['access_key_1_active'], iam_user['access_key_1_last_used_date']) and \
-            parse(iam_user['access_key_1_last_used_date']) > no_activity_since:
+    if (
+        is_credential_active(
+            iam_user["access_key_1_active"], iam_user["access_key_1_last_used_date"]
+        )
+        and parse(iam_user["access_key_1_last_used_date"]) > no_activity_since
+    ):
         return False
 
-    if is_credential_active(iam_user['access_key_2_active'], iam_user['access_key_2_last_used_date']) and \
-            parse(iam_user['access_key_2_last_used_date']) > no_activity_since:
+    if (
+        is_credential_active(
+            iam_user["access_key_2_active"], iam_user["access_key_2_last_used_date"]
+        )
+        and parse(iam_user["access_key_2_last_used_date"]) > no_activity_since
+    ):
         return False
 
-    if is_credential_active(iam_user['password_enabled'], iam_user['password_last_used']) and \
-            parse(iam_user['password_last_used']) > no_activity_since:
+    if (
+        is_credential_active(
+            iam_user["password_enabled"], iam_user["password_last_used"]
+        )
+        and parse(iam_user["password_last_used"]) > no_activity_since
+    ):
         return False
 
     return True
 
 
 def is_credential_active(credential_active, credential_last_used):
-    return credential_active == 'true' and \
-            credential_last_used not in ['N/A', 'no_information']
+    return credential_active == "true" and credential_last_used not in [
+        "N/A",
+        "no_information",
+    ]
 
 
 def is_access_key_expired(iam_access_key, access_key_expiration_date):
@@ -131,15 +145,15 @@ def is_access_key_expired(iam_access_key, access_key_expiration_date):
     True
     """
 
-    if iam_access_key['Status'] != 'Active':
+    if iam_access_key["Status"] != "Active":
         return False
 
     # This type checking is done because the caching in pytest-services will
     # store datetime objects as strings. If the results are not from the cache,
     # then `CreateDate` will be a datetime object, else it will be a string.
-    if isinstance(iam_access_key['CreateDate'], datetime):
-        access_key_create_date = iam_access_key['CreateDate']
+    if isinstance(iam_access_key["CreateDate"], datetime):
+        access_key_create_date = iam_access_key["CreateDate"]
     else:
-        access_key_create_date = parse(iam_access_key['CreateDate'])
+        access_key_create_date = parse(iam_access_key["CreateDate"])
 
     return access_key_expiration_date > access_key_create_date

--- a/aws/iam/meta_test_resources.py
+++ b/aws/iam/meta_test_resources.py
@@ -1,31 +1,31 @@
 
 
-from aws.iam.resources import (
-    iam_users,
-    iam_inline_policies,
-)
+from aws.iam.resources import iam_users, iam_inline_policies
 
 
 def test_iam_users():
     assert iam_users() == [
         {
-            'Arn': 'arn:aws:iam::123456789012:user/hobbes',
-            'CreateDate': '1985-11-18T00:01:10+00:00',
-            'PasswordLastUsed': '2018-01-09T20:43:00+00:00',
-            'Path': '/',
-            'UserId': 'H0BBIHMA0CZ0R0K0MN00C',
-            'UserName': 'tigerone',
-            '__pytest_meta': {'profile': 'example-account', 'region': 'us-east-1'}},
+            "Arn": "arn:aws:iam::123456789012:user/hobbes",
+            "CreateDate": "1985-11-18T00:01:10+00:00",
+            "PasswordLastUsed": "2018-01-09T20:43:00+00:00",
+            "Path": "/",
+            "UserId": "H0BBIHMA0CZ0R0K0MN00C",
+            "UserName": "tigerone",
+            "__pytest_meta": {"profile": "example-account", "region": "us-east-1"},
+        },
         {
-            'Arn': 'arn:aws:iam::123456789012:user/calvin',
-            'CreateDate': '1985-11-18T00:01:10+00:00',
-            'PasswordLastUsed': '2008-01-09T20:43:00+00:00',
-            'Path': '/',
-            'UserId': 'CALCIHMA0CZ0R0K0MN00C',
-            'UserName': 'spacemanspiff',
-            '__pytest_meta': {'profile': 'example-account', 'region': 'us-east-1'}}]
+            "Arn": "arn:aws:iam::123456789012:user/calvin",
+            "CreateDate": "1985-11-18T00:01:10+00:00",
+            "PasswordLastUsed": "2008-01-09T20:43:00+00:00",
+            "Path": "/",
+            "UserId": "CALCIHMA0CZ0R0K0MN00C",
+            "UserName": "spacemanspiff",
+            "__pytest_meta": {"profile": "example-account", "region": "us-east-1"},
+        },
+    ]
 
 
 def test_iam_inline_policies_for_user_without_policies():
     # extracts empty 'PolicyNames'
-    assert iam_inline_policies(username='tigerone') == []
+    assert iam_inline_policies(username="tigerone") == []

--- a/aws/iam/test_iam_access_key_is_old.py
+++ b/aws/iam/test_iam_access_key_is_old.py
@@ -11,8 +11,9 @@ def access_key_expiration_date(pytestconfig):
 
 @pytest.mark.iam
 @pytest.mark.parametrize(
-        'iam_access_key',
-        iam_get_all_access_keys(),
-        ids=lambda access_key: access_key['UserName'])
+    "iam_access_key",
+    iam_get_all_access_keys(),
+    ids=lambda access_key: access_key["UserName"],
+)
 def test_iam_access_key_is_old(iam_access_key, access_key_expiration_date):
     assert not is_access_key_expired(iam_access_key, access_key_expiration_date)

--- a/aws/iam/test_iam_admin_user_with_access_keys.py
+++ b/aws/iam/test_iam_admin_user_with_access_keys.py
@@ -5,9 +5,10 @@ from aws.iam.resources import iam_admin_users_with_credential_report
 
 @pytest.mark.iam
 @pytest.mark.parametrize(
-        'iam_admin_user',
-        iam_admin_users_with_credential_report(),
-        ids=lambda login: login['UserName'])
+    "iam_admin_user",
+    iam_admin_users_with_credential_report(),
+    ids=lambda login: login["UserName"],
+)
 def test_iam_admin_user_with_access_key(iam_admin_user):
     """Test that all "admin" users do not have access keys
     associated to their user.
@@ -15,7 +16,13 @@ def test_iam_admin_user_with_access_key(iam_admin_user):
     Note: Due to the naive mechanism for determing what an "admin" is, this test
     can easily have both false positives and (more likely) false negatives.
     """
-    assert iam_admin_user['CredentialReport']['access_key_1_active'] != 'true', \
-        'Access key found for admin user: {}'.format(iam_admin_user['UserName'])
-    assert iam_admin_user['CredentialReport']['access_key_2_active'] != 'true', \
-        'Access key found for admin user: {}'.format(iam_admin_user['UserName'])
+    assert (
+        iam_admin_user["CredentialReport"]["access_key_1_active"] != "true"
+    ), "Access key found for admin user: {}".format(
+        iam_admin_user["UserName"]
+    )
+    assert (
+        iam_admin_user["CredentialReport"]["access_key_2_active"] != "true"
+    ), "Access key found for admin user: {}".format(
+        iam_admin_user["UserName"]
+    )

--- a/aws/iam/test_iam_admin_user_without_mfa.py
+++ b/aws/iam/test_iam_admin_user_without_mfa.py
@@ -1,16 +1,14 @@
 import pytest
 
-from aws.iam.resources import (
-    iam_admin_login_profiles,
-    iam_admin_mfa_devices,
-)
+from aws.iam.resources import iam_admin_login_profiles, iam_admin_mfa_devices
 
 
 @pytest.mark.iam
 @pytest.mark.parametrize(
-        ['iam_login_profile', 'iam_user_mfa_devices'],
-        zip(iam_admin_login_profiles(), iam_admin_mfa_devices()),
-        ids=lambda login: login['UserName'])
+    ["iam_login_profile", "iam_user_mfa_devices"],
+    zip(iam_admin_login_profiles(), iam_admin_mfa_devices()),
+    ids=lambda login: login["UserName"],
+)
 def test_iam_admin_user_without_mfa(iam_login_profile, iam_user_mfa_devices):
     """Test that all "admin" users with console access also have an MFA device.
 
@@ -18,5 +16,6 @@ def test_iam_admin_user_without_mfa(iam_login_profile, iam_user_mfa_devices):
     can easily have both false positives and (more likely) false negatives.
     """
     if bool(iam_login_profile):
-        assert len(iam_user_mfa_devices) > 0, \
-            'No MFA Device found for {}'.format(iam_login_profile['UserName'])
+        assert len(iam_user_mfa_devices) > 0, "No MFA Device found for {}".format(
+            iam_login_profile["UserName"]
+        )

--- a/aws/iam/test_iam_cross_account_admin_roles_require_mfa.py
+++ b/aws/iam/test_iam_cross_account_admin_roles_require_mfa.py
@@ -5,9 +5,8 @@ from aws.iam.resources import iam_admin_roles
 
 @pytest.mark.iam
 @pytest.mark.parametrize(
-        'iam_admin_role',
-        iam_admin_roles(),
-        ids=lambda role: role['RoleName'])
+    "iam_admin_role", iam_admin_roles(), ids=lambda role: role["RoleName"]
+)
 def test_iam_cross_account_admin_roles_require_mfa(iam_admin_role):
     """Test that all IAM Roles that include admin policies and have cross account
     trust relationships require MFA.
@@ -17,6 +16,8 @@ def test_iam_cross_account_admin_roles_require_mfa(iam_admin_role):
     """
     for statement in iam_admin_role["AssumeRolePolicyDocument"]["Statement"]:
         if statement["Action"].startswith("sts") and "AWS" in statement["Principal"]:
-            assert 'Condition' in statement
-            assert 'aws:MultiFactorAuthPresent' in statement['Condition']['Bool']
-            assert statement['Condition']['Bool']['aws:MultiFactorAuthPresent'] == 'true'
+            assert "Condition" in statement
+            assert "aws:MultiFactorAuthPresent" in statement["Condition"]["Bool"]
+            assert (
+                statement["Condition"]["Bool"]["aws:MultiFactorAuthPresent"] == "true"
+            )

--- a/aws/iam/test_iam_user_is_inactive.py
+++ b/aws/iam/test_iam_user_is_inactive.py
@@ -16,16 +16,16 @@ def created_after(pytestconfig):
 
 @pytest.mark.iam
 @pytest.mark.parametrize(
-        'iam_user_row',
-        iam_get_credential_report(),
-        ids=lambda user: user['user'])
+    "iam_user_row", iam_get_credential_report(), ids=lambda user: user["user"]
+)
 def test_iam_user_is_inactive(iam_user_row, no_activity_since, created_after):
     """Tests if a user is inactive. This is done by checking the last time
     an access key was used or the user logged into the console. If the config
     settings are not present, it defaults to considering a year ago as inactive
     and giving a user a 1 week grace period (created_after).
     """
-    assert not user_is_inactive(iam_user_row, no_activity_since, created_after), \
-        "User {} hasn't been used since {} and is out of the grace period.".format(
-            iam_user_row['user'], no_activity_since.date()
-        )
+    assert not user_is_inactive(
+        iam_user_row, no_activity_since, created_after
+    ), "User {} hasn't been used since {} and is out of the grace period.".format(
+        iam_user_row["user"], no_activity_since.date()
+    )

--- a/aws/iam/test_iam_user_without_mfa.py
+++ b/aws/iam/test_iam_user_without_mfa.py
@@ -1,19 +1,18 @@
 import pytest
 
-from aws.iam.resources import (
-    iam_user_login_profiles,
-    iam_user_mfa_devices,
-)
+from aws.iam.resources import iam_user_login_profiles, iam_user_mfa_devices
 
 
 @pytest.mark.iam
 @pytest.mark.parametrize(
-        ['iam_login_profile', 'iam_user_mfa_devices'],
-        zip(iam_user_login_profiles(), iam_user_mfa_devices()),
-        ids=lambda login: login['UserName'])
+    ["iam_login_profile", "iam_user_mfa_devices"],
+    zip(iam_user_login_profiles(), iam_user_mfa_devices()),
+    ids=lambda login: login["UserName"],
+)
 def test_iam_user_without_mfa(iam_login_profile, iam_user_mfa_devices):
     """Test that all users with console access also have an MFA device.
     """
     if bool(iam_login_profile):
-        assert len(iam_user_mfa_devices) > 0, \
-            'No MFA Device found for {}'.format(iam_login_profile['UserName'])
+        assert len(iam_user_mfa_devices) > 0, "No MFA Device found for {}".format(
+            iam_login_profile["UserName"]
+        )

--- a/aws/rds/helpers.py
+++ b/aws/rds/helpers.py
@@ -1,5 +1,3 @@
-
-
 def is_rds_db_snapshot_attr_public_access(rds_db_snapshot_attribute):
     """
     Checks whether a RDS snapshot attribute is:
@@ -30,8 +28,10 @@ def is_rds_db_snapshot_attr_public_access(rds_db_snapshot_attribute):
     ...
     TypeError: 'NoneType' object is not subscriptable
     """
-    return rds_db_snapshot_attribute['AttributeName'] == 'restore' and \
-        'any' in rds_db_snapshot_attribute['AttributeValues']
+    return (
+        rds_db_snapshot_attribute["AttributeName"] == "restore"
+        and "any" in rds_db_snapshot_attribute["AttributeValues"]
+    )
 
 
 def does_rds_db_security_group_grant_public_access(sg):
@@ -45,7 +45,10 @@ def does_rds_db_security_group_grant_public_access(sg):
     >>> does_rds_db_security_group_grant_public_access({"IPRanges": []})
     False
     """
-    return any(ipr['CIDRIP'] == '0.0.0.0/0' and ipr['Status'] == 'authorized' for ipr in sg['IPRanges'])
+    return any(
+        ipr["CIDRIP"] == "0.0.0.0/0" and ipr["Status"] == "authorized"
+        for ipr in sg["IPRanges"]
+    )
 
 
 def does_vpc_security_group_grant_public_access(sg):
@@ -62,8 +65,16 @@ def does_vpc_security_group_grant_public_access(sg):
     ... {'IpPermissions': [{'Ipv6Ranges': [], 'IpRanges': [{'CidrIp': '192.168.1.0/0'}]}]})
     False
     """
-    public_ipv4 = any(ipr['CidrIp'] == '0.0.0.0/0' for ipp in sg['IpPermissions'] for ipr in ipp['IpRanges'])
-    public_ipv6 = any(ipr['CidrIpv6'] == '::/0' for ipp in sg['IpPermissions'] for ipr in ipp['Ipv6Ranges'])
+    public_ipv4 = any(
+        ipr["CidrIp"] == "0.0.0.0/0"
+        for ipp in sg["IpPermissions"]
+        for ipr in ipp["IpRanges"]
+    )
+    public_ipv6 = any(
+        ipr["CidrIpv6"] == "::/0"
+        for ipp in sg["IpPermissions"]
+        for ipr in ipp["Ipv6Ranges"]
+    )
     return public_ipv4 or public_ipv6
 
 
@@ -88,7 +99,7 @@ def is_rds_db_instance_encrypted(rds_db_instance):
     ...
     TypeError: 'NoneType' object is not subscriptable
     """
-    return bool(rds_db_instance['StorageEncrypted'])
+    return bool(rds_db_instance["StorageEncrypted"])
 
 
 def is_rds_db_snapshot_encrypted(rds_db_snapshot):
@@ -112,4 +123,4 @@ def is_rds_db_snapshot_encrypted(rds_db_snapshot):
     ...
     TypeError: 'NoneType' object is not subscriptable
     """
-    return bool(rds_db_snapshot['Encrypted'])
+    return bool(rds_db_snapshot["Encrypted"])

--- a/aws/rds/resources.py
+++ b/aws/rds/resources.py
@@ -5,28 +5,35 @@ from conftest import botocore_client
 
 def rds_db_instances():
     "http://botocore.readthedocs.io/en/latest/reference/services/rds.html#RDS.Client.describe_db_instances"
-    return botocore_client.get('rds', 'describe_db_instances', [], {}).extract_key('DBInstances').flatten().values()
+    return (
+        botocore_client.get("rds", "describe_db_instances", [], {})
+        .extract_key("DBInstances")
+        .flatten()
+        .values()
+    )
 
 
 def rds_db_instance_tags(db):
     "http://botocore.readthedocs.io/en/latest/reference/services/rds.html#RDS.Client.list_tags_for_resource"
-    return botocore_client.get(
-        service_name='rds',
-        method_name='list_tags_for_resource',
-        call_args=[],
-        call_kwargs={'ResourceName': db['DBInstanceArn']},
-        profiles=[db['__pytest_meta']['profile']],
-        regions=[db['__pytest_meta']['region']],
-        result_from_error=lambda e, call: [])\
-        .extract_key('TagList')\
-        .flatten()\
+    return (
+        botocore_client.get(
+            service_name="rds",
+            method_name="list_tags_for_resource",
+            call_args=[],
+            call_kwargs={"ResourceName": db["DBInstanceArn"]},
+            profiles=[db["__pytest_meta"]["profile"]],
+            regions=[db["__pytest_meta"]["region"]],
+            result_from_error=lambda e, call: [],
+        )
+        .extract_key("TagList")
+        .flatten()
         .values()
+    )
 
 
 def rds_db_instances_with_tags():
     return [
-        {**{'TagList': rds_db_instance_tags(db=db)}, **db}
-        for db in rds_db_instances()
+        {**{"TagList": rds_db_instance_tags(db=db)}, **db} for db in rds_db_instances()
     ]
 
 
@@ -34,41 +41,59 @@ def rds_db_instances_vpc_security_groups():
     "http://botocore.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.describe_security_groups"
     return [
         botocore_client.get(
-            service_name='ec2',
-            method_name='describe_security_groups',
+            service_name="ec2",
+            method_name="describe_security_groups",
             call_args=[],
-            call_kwargs={'Filters': [{'Name': 'group-id', 'Values': [
-                sg['VpcSecurityGroupId'] for sg in instance['VpcSecurityGroups'] if sg['Status'] == 'active'
-            ]}]},
-            profiles=[instance['__pytest_meta']['profile']],
-            regions=[instance['__pytest_meta']['region']],
-            result_from_error=lambda e, call: {'SecurityGroups': []})  # treat not found as empty list
-        .extract_key('SecurityGroups')
+            call_kwargs={
+                "Filters": [
+                    {
+                        "Name": "group-id",
+                        "Values": [
+                            sg["VpcSecurityGroupId"]
+                            for sg in instance["VpcSecurityGroups"]
+                            if sg["Status"] == "active"
+                        ],
+                    }
+                ]
+            },
+            profiles=[instance["__pytest_meta"]["profile"]],
+            regions=[instance["__pytest_meta"]["region"]],
+            result_from_error=lambda e, call: {"SecurityGroups": []},
+        )  # treat not found as empty list
+        .extract_key("SecurityGroups")
         .flatten()
         .values()
-        for instance in rds_db_instances()]
+        for instance in rds_db_instances()
+    ]
 
 
 def rds_db_snapshots():
     "http://botocore.readthedocs.io/en/latest/reference/services/rds.html#RDS.Client.describe_db_snapshots"
-    return botocore_client.get('rds', 'describe_db_snapshots', [], {}).extract_key('DBSnapshots').flatten().values()
+    return (
+        botocore_client.get("rds", "describe_db_snapshots", [], {})
+        .extract_key("DBSnapshots")
+        .flatten()
+        .values()
+    )
 
 
 def rds_db_snapshots_attributes():
     "http://botocore.readthedocs.io/en/latest/reference/services/rds.html#RDS.Client.describe_db_snapshot_attributes"
-    empty_attrs = {'DBSnapshotAttributesResult': {'DBSnapshotAttributes': []}}
-    return [botocore_client.get(
-        service_name='rds',
-        method_name='describe_db_snapshot_attributes',
-        call_args=[],
-        call_kwargs={'DBSnapshotIdentifier': snapshot['DBSnapshotIdentifier']},
-        profiles=[snapshot['__pytest_meta']['profile']],
-        regions=[snapshot['__pytest_meta']['region']],
-        result_from_error=lambda e, call: empty_attrs,  # treat not found as empty list
-    )
-      .extract_key('DBSnapshotAttributesResult')
-      .extract_key('DBSnapshotAttributes')
-      .values()[0] for snapshot in rds_db_snapshots()
+    empty_attrs = {"DBSnapshotAttributesResult": {"DBSnapshotAttributes": []}}
+    return [
+        botocore_client.get(
+            service_name="rds",
+            method_name="describe_db_snapshot_attributes",
+            call_args=[],
+            call_kwargs={"DBSnapshotIdentifier": snapshot["DBSnapshotIdentifier"]},
+            profiles=[snapshot["__pytest_meta"]["profile"]],
+            regions=[snapshot["__pytest_meta"]["region"]],
+            result_from_error=lambda e, call: empty_attrs,  # treat not found as empty list
+        )
+        .extract_key("DBSnapshotAttributesResult")
+        .extract_key("DBSnapshotAttributes")
+        .values()[0]
+        for snapshot in rds_db_snapshots()
     ]
 
 
@@ -76,7 +101,9 @@ def rds_db_security_groups():
     "http://botocore.readthedocs.io/en/latest/reference/services/rds.html#RDS.Client.describe_db_security_groups"
     sgs = []
 
-    for response in botocore_client.get('rds', 'describe_db_security_groups', [], {}).values():
-        sgs.extend(response['DBSecurityGroups'])
+    for response in botocore_client.get(
+        "rds", "describe_db_security_groups", [], {}
+    ).values():
+        sgs.extend(response["DBSecurityGroups"])
 
     return sgs

--- a/aws/rds/test_rds_db_instance_backup_enabled.py
+++ b/aws/rds/test_rds_db_instance_backup_enabled.py
@@ -5,9 +5,12 @@ from aws.rds.resources import rds_db_instances_with_tags
 
 
 @pytest.mark.rds
-@pytest.mark.parametrize('rds_db_instance',
-                         rds_db_instances_with_tags(),
-                         ids=lambda db_instance: db_instance['DBInstanceIdentifier'])
+@pytest.mark.parametrize(
+    "rds_db_instance",
+    rds_db_instances_with_tags(),
+    ids=lambda db_instance: db_instance["DBInstanceIdentifier"],
+)
 def test_rds_db_instance_backup_enabled(rds_db_instance):
-    assert rds_db_instance['BackupRetentionPeriod'] > 0, \
-        'Backups disabled for {}'.format(rds_db_instance['DBInstanceIdentifier'])
+    assert (
+        rds_db_instance["BackupRetentionPeriod"] > 0
+    ), "Backups disabled for {}".format(rds_db_instance["DBInstanceIdentifier"])

--- a/aws/rds/test_rds_db_instance_encrypted.py
+++ b/aws/rds/test_rds_db_instance_encrypted.py
@@ -5,8 +5,10 @@ from aws.rds.helpers import is_rds_db_instance_encrypted
 
 
 @pytest.mark.rds
-@pytest.mark.parametrize('rds_db_instance',
-                         rds_db_instances_with_tags(),
-                         ids=lambda db_instance: db_instance['DBInstanceIdentifier'])
+@pytest.mark.parametrize(
+    "rds_db_instance",
+    rds_db_instances_with_tags(),
+    ids=lambda db_instance: db_instance["DBInstanceIdentifier"],
+)
 def test_rds_db_instance_encrypted(rds_db_instance):
     assert is_rds_db_instance_encrypted(rds_db_instance)

--- a/aws/rds/test_rds_db_instance_is_multiaz.py
+++ b/aws/rds/test_rds_db_instance_is_multiaz.py
@@ -5,9 +5,14 @@ from aws.rds.resources import rds_db_instances_with_tags
 
 
 @pytest.mark.rds
-@pytest.mark.parametrize('rds_db_instance',
-                         rds_db_instances_with_tags(),
-                         ids=lambda db_instance: db_instance['DBInstanceIdentifier'])
+@pytest.mark.parametrize(
+    "rds_db_instance",
+    rds_db_instances_with_tags(),
+    ids=lambda db_instance: db_instance["DBInstanceIdentifier"],
+)
 def test_rds_db_instance_is_multiaz(rds_db_instance):
-    assert rds_db_instance['MultiAZ'] is False, \
-        '{} is in a single availability zone'.format(rds_db_instance['DBInstanceIdentifier'])
+    assert (
+        rds_db_instance["MultiAZ"] is False
+    ), "{} is in a single availability zone".format(
+        rds_db_instance["DBInstanceIdentifier"]
+    )

--- a/aws/rds/test_rds_db_instance_is_postgres_with_invalid_certificate.py
+++ b/aws/rds/test_rds_db_instance_is_postgres_with_invalid_certificate.py
@@ -9,18 +9,22 @@ from aws.rds.resources import rds_db_instances_with_tags
 
 
 @pytest.mark.rds
-@pytest.mark.parametrize('rds_db_instance',
-                         rds_db_instances_with_tags(),
-                         ids=lambda db_instance: db_instance['DBInstanceIdentifier'])
+@pytest.mark.parametrize(
+    "rds_db_instance",
+    rds_db_instances_with_tags(),
+    ids=lambda db_instance: db_instance["DBInstanceIdentifier"],
+)
 def test_rds_db_instance_is_postgres_with_invalid_certificate(rds_db_instance):
-    if rds_db_instance['Engine'] != 'postgres':
-        pytest.skip('RDS DB instance engine is not Postgres.')
+    if rds_db_instance["Engine"] != "postgres":
+        pytest.skip("RDS DB instance engine is not Postgres.")
 
-    if rds_db_instance['DBInstanceStatus'] == 'creating':
+    if rds_db_instance["DBInstanceStatus"] == "creating":
         pytest.skip('RDS DB instance status is still "creating".')
 
-    ict = rds_db_instance['InstanceCreateTime']
+    ict = rds_db_instance["InstanceCreateTime"]
     if isinstance(ict, str):
         ict = parse_timestamp(ict)
 
-    assert ict > datetime.datetime(2014, 8, 5, tzinfo=datetime.timezone(datetime.timedelta(), 'utc'))
+    assert ict > datetime.datetime(
+        2014, 8, 5, tzinfo=datetime.timezone(datetime.timedelta(), "utc")
+    )

--- a/aws/rds/test_rds_db_instance_minor_version_updates_enabled.py
+++ b/aws/rds/test_rds_db_instance_minor_version_updates_enabled.py
@@ -5,9 +5,11 @@ from aws.rds.resources import rds_db_instances_with_tags
 
 
 @pytest.mark.rds
-@pytest.mark.parametrize('rds_db_instance',
-                         rds_db_instances_with_tags(),
-                         ids=lambda db_instance: db_instance['DBInstanceIdentifier'])
+@pytest.mark.parametrize(
+    "rds_db_instance",
+    rds_db_instances_with_tags(),
+    ids=lambda db_instance: db_instance["DBInstanceIdentifier"],
+)
 def test_rds_db_instance_minor_version_updates_enabled(rds_db_instance):
     """
     Enable automatic minor version updates (e.g. 5.6.26 to 5.6.27)
@@ -17,8 +19,14 @@ def test_rds_db_instance_minor_version_updates_enabled(rds_db_instance):
 
     http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Upgrading.html
     """
-    if rds_db_instance['Engine'] not in ['mariadb', 'mysql', 'postgres']:
-        pytest.skip('Engine type %s does not support minor version updates.' % rds_db_instance['Engine'])
+    if rds_db_instance["Engine"] not in ["mariadb", "mysql", "postgres"]:
+        pytest.skip(
+            "Engine type %s does not support minor version updates."
+            % rds_db_instance["Engine"]
+        )
 
-    assert rds_db_instance['AutoMinorVersionUpgrade'], \
-        'Minor version automatic upgrades disabled for {}'.format(rds_db_instance['DBInstanceIdentifier'])
+    assert rds_db_instance[
+        "AutoMinorVersionUpgrade"
+    ], "Minor version automatic upgrades disabled for {}".format(
+        rds_db_instance["DBInstanceIdentifier"]
+    )

--- a/aws/rds/test_rds_db_instance_not_publicly_accessible_by_vpc_sg.py
+++ b/aws/rds/test_rds_db_instance_not_publicly_accessible_by_vpc_sg.py
@@ -4,25 +4,30 @@ from aws.rds.resources import (
     rds_db_instances_with_tags,
     rds_db_instances_vpc_security_groups,
 )
-from aws.rds.helpers import \
-    does_vpc_security_group_grant_public_access
+from aws.rds.helpers import does_vpc_security_group_grant_public_access
 
 
 @pytest.mark.rds
 @pytest.mark.parametrize(
-    ['rds_db_instance', 'ec2_security_groups'],
+    ["rds_db_instance", "ec2_security_groups"],
     zip(rds_db_instances_with_tags(), rds_db_instances_vpc_security_groups()),
-    ids=lambda db_instance: db_instance['DBInstanceIdentifier']
+    ids=lambda db_instance: db_instance["DBInstanceIdentifier"],
 )
-def test_rds_db_instance_not_publicly_accessible_by_vpc_security_group(rds_db_instance, ec2_security_groups):
+def test_rds_db_instance_not_publicly_accessible_by_vpc_security_group(
+    rds_db_instance, ec2_security_groups
+):
     """
     Checks whether any VPC/EC2 security groups that are attached to an RDS instance
     allow for access from the public internet.
     """
     if not ec2_security_groups:
-        assert not rds_db_instance['VpcSecurityGroups']
+        assert not rds_db_instance["VpcSecurityGroups"]
     else:
-        assert set(sg['GroupId'] for sg in ec2_security_groups) == \
-          set(sg['VpcSecurityGroupId'] for sg in rds_db_instance['VpcSecurityGroups'])
+        assert set(sg["GroupId"] for sg in ec2_security_groups) == set(
+            sg["VpcSecurityGroupId"] for sg in rds_db_instance["VpcSecurityGroups"]
+        )
 
-        assert not any(does_vpc_security_group_grant_public_access(sg) for sg in ec2_security_groups)
+        assert not any(
+            does_vpc_security_group_grant_public_access(sg)
+            for sg in ec2_security_groups
+        )

--- a/aws/rds/test_rds_db_security_group_does_not_grant_public_access.py
+++ b/aws/rds/test_rds_db_security_group_does_not_grant_public_access.py
@@ -1,15 +1,15 @@
 import pytest
 
 from aws.rds.resources import rds_db_security_groups
-from aws.rds.helpers import \
-    does_rds_db_security_group_grant_public_access
+from aws.rds.helpers import does_rds_db_security_group_grant_public_access
 
 
 @pytest.mark.rds
 @pytest.mark.parametrize(
-    'rds_db_security_group',
+    "rds_db_security_group",
     rds_db_security_groups(),
-    ids=lambda sg: sg['DBSecurityGroupArn'])
+    ids=lambda sg: sg["DBSecurityGroupArn"],
+)
 def test_rds_db_security_group_does_not_grant_public_access(rds_db_security_group):
     """
     Checks whether any RDS security group allows for inbound

--- a/aws/rds/test_rds_db_snapshot_encrypted.py
+++ b/aws/rds/test_rds_db_snapshot_encrypted.py
@@ -5,8 +5,10 @@ from aws.rds.helpers import is_rds_db_snapshot_encrypted
 
 
 @pytest.mark.rds
-@pytest.mark.parametrize('rds_db_snapshot',
-                         rds_db_snapshots(),
-                         ids=lambda snapshot: snapshot['DBSnapshotArn'])
+@pytest.mark.parametrize(
+    "rds_db_snapshot",
+    rds_db_snapshots(),
+    ids=lambda snapshot: snapshot["DBSnapshotArn"],
+)
 def test_rds_db_snapshot_encrypted(rds_db_snapshot):
     assert is_rds_db_snapshot_encrypted(rds_db_snapshot)

--- a/aws/rds/test_rds_db_snapshot_not_publicly_accessible.py
+++ b/aws/rds/test_rds_db_snapshot_not_publicly_accessible.py
@@ -1,18 +1,17 @@
 import pytest
 
-from aws.rds.resources import (
-    rds_db_snapshots,
-    rds_db_snapshots_attributes,
-)
-from aws.rds.helpers import \
-    is_rds_db_snapshot_attr_public_access
+from aws.rds.resources import rds_db_snapshots, rds_db_snapshots_attributes
+from aws.rds.helpers import is_rds_db_snapshot_attr_public_access
 
 
 @pytest.mark.rds
 @pytest.mark.parametrize(
-    ['rds_db_snapshot', 'rds_db_snapshot_attributes'],
+    ["rds_db_snapshot", "rds_db_snapshot_attributes"],
     zip(rds_db_snapshots(), rds_db_snapshots_attributes()),
-    ids=lambda snapshot: snapshot['DBSnapshotArn'])
-def test_rds_db_snapshot_not_publicly_accessible(rds_db_snapshot, rds_db_snapshot_attributes):
+    ids=lambda snapshot: snapshot["DBSnapshotArn"],
+)
+def test_rds_db_snapshot_not_publicly_accessible(
+    rds_db_snapshot, rds_db_snapshot_attributes
+):
     for attr in rds_db_snapshot_attributes:
         assert not is_rds_db_snapshot_attr_public_access(attr)

--- a/aws/redshift/helpers.py
+++ b/aws/redshift/helpers.py
@@ -1,7 +1,5 @@
-
-
 def redshift_cluster_security_group_test_id(security_group):
-    return security_group['ClusterSecurityGroupName']
+    return security_group["ClusterSecurityGroupName"]
 
 
 def redshift_cluster_security_group_is_open_to_all_ips(security_group):
@@ -24,8 +22,8 @@ def redshift_cluster_security_group_is_open_to_all_ips(security_group):
     False
 
     """
-    for ipr in security_group.get('IPRanges', []):
-        if ipr.get('CIDRIP', None) in ['0.0.0.0/0', '::/0']:
+    for ipr in security_group.get("IPRanges", []):
+        if ipr.get("CIDRIP", None) in ["0.0.0.0/0", "::/0"]:
             return True
 
     return False

--- a/aws/redshift/resources.py
+++ b/aws/redshift/resources.py
@@ -5,19 +5,25 @@ from conftest import botocore_client
 
 def redshift_clusters():
     "botocore.readthedocs.io/en/latest/reference/services/redshift.html#Redshift.Client.describe_clusters"
-    return botocore_client.get(
-        'redshift', 'describe_clusters', [], {})\
-        .extract_key('Clusters')\
-        .flatten()\
+    return (
+        botocore_client.get("redshift", "describe_clusters", [], {})
+        .extract_key("Clusters")
+        .flatten()
         .values()
+    )
 
 
 def redshift_cluster_security_groups():
-    "http://botocore.readthedocs.io/en/latest/reference/services/redshift.html#Redshift.Client.describe_cluster_security_groups" # NOQA
-    return botocore_client.get(
-        'redshift',
-        'describe_cluster_security_groups',
-        [],
-        {},
-        result_from_error=lambda error, call: {'ClusterSecurityGroups': []}
-    ).extract_key('ClusterSecurityGroups').flatten().values()
+    "http://botocore.readthedocs.io/en/latest/reference/services/redshift.html#Redshift.Client.describe_cluster_security_groups"  # NOQA
+    return (
+        botocore_client.get(
+            "redshift",
+            "describe_cluster_security_groups",
+            [],
+            {},
+            result_from_error=lambda error, call: {"ClusterSecurityGroups": []},
+        )
+        .extract_key("ClusterSecurityGroups")
+        .flatten()
+        .values()
+    )

--- a/aws/redshift/test_redshift_security_group_does_not_allow_all_ips_access.py
+++ b/aws/redshift/test_redshift_security_group_does_not_allow_all_ips_access.py
@@ -11,7 +11,7 @@ from aws.redshift.helpers import (
 
 @pytest.mark.redshift
 @pytest.mark.parametrize(
-    'security_group',
+    "security_group",
     redshift_cluster_security_groups(),
     ids=redshift_cluster_security_group_test_id,
 )

--- a/aws/s3/resources.py
+++ b/aws/s3/resources.py
@@ -5,21 +5,27 @@ from conftest import botocore_client
 
 def s3_buckets():
     "http://botocore.readthedocs.io/en/latest/reference/services/s3.html#S3.Client.list_buckets"
-    return botocore_client.get('s3', 'list_buckets', [], {}).extract_key('Buckets').flatten().values()
+    return (
+        botocore_client.get("s3", "list_buckets", [], {})
+        .extract_key("Buckets")
+        .flatten()
+        .values()
+    )
 
 
 def s3_buckets_cors_rules():
     "http://botocore.readthedocs.io/en/latest/reference/services/s3.html#S3.Client.get_bucket_cors"
     return [
-        botocore_client
-        .get('s3',
-             'get_bucket_cors',
-             [],
-             {'Bucket': bucket['Name']},
-             profiles=[bucket['__pytest_meta']['profile']],
-             regions=[bucket['__pytest_meta']['region']],
-             result_from_error=lambda error, call: {'CORSRules': None})
-        .extract_key('CORSRules')
+        botocore_client.get(
+            "s3",
+            "get_bucket_cors",
+            [],
+            {"Bucket": bucket["Name"]},
+            profiles=[bucket["__pytest_meta"]["profile"]],
+            regions=[bucket["__pytest_meta"]["region"]],
+            result_from_error=lambda error, call: {"CORSRules": None},
+        )
+        .extract_key("CORSRules")
         .values()[0]
         for bucket in s3_buckets()
     ]
@@ -28,14 +34,15 @@ def s3_buckets_cors_rules():
 def s3_buckets_logging():
     "http://botocore.readthedocs.io/en/latest/reference/services/s3.html#S3.Client.get_bucket_logging"
     return [
-        botocore_client
-        .get('s3',
-             'get_bucket_logging',
-             [],
-             {'Bucket': bucket['Name']},
-             profiles=[bucket['__pytest_meta']['profile']],
-             regions=[bucket['__pytest_meta']['region']])
-        .extract_key('LoggingEnabled', default=False)
+        botocore_client.get(
+            "s3",
+            "get_bucket_logging",
+            [],
+            {"Bucket": bucket["Name"]},
+            profiles=[bucket["__pytest_meta"]["profile"]],
+            regions=[bucket["__pytest_meta"]["region"]],
+        )
+        .extract_key("LoggingEnabled", default=False)
         .values()[0]
         for bucket in s3_buckets()
     ]
@@ -44,14 +51,14 @@ def s3_buckets_logging():
 def s3_buckets_acls():
     "http://botocore.readthedocs.io/en/latest/reference/services/s3.html#S3.Client.get_bucket_acl"
     return [
-        botocore_client
-        .get('s3',
-             'get_bucket_acl',
-             [],
-             {'Bucket': bucket['Name']},
-             profiles=[bucket['__pytest_meta']['profile']],
-             regions=[bucket['__pytest_meta']['region']])
-        .values()[0]
+        botocore_client.get(
+            "s3",
+            "get_bucket_acl",
+            [],
+            {"Bucket": bucket["Name"]},
+            profiles=[bucket["__pytest_meta"]["profile"]],
+            regions=[bucket["__pytest_meta"]["region"]],
+        ).values()[0]
         for bucket in s3_buckets()
     ]
 
@@ -59,48 +66,53 @@ def s3_buckets_acls():
 def s3_buckets_versioning():
     "http://botocore.readthedocs.io/en/latest/reference/services/s3.html#S3.Client.get_bucket_versioning"
     return [
-        botocore_client
-        .get('s3',
-             'get_bucket_versioning',
-             [],
-             {'Bucket': bucket['Name']},
-             profiles=[bucket['__pytest_meta']['profile']],
-             regions=[bucket['__pytest_meta']['region']])
-        .values()[0]
+        botocore_client.get(
+            "s3",
+            "get_bucket_versioning",
+            [],
+            {"Bucket": bucket["Name"]},
+            profiles=[bucket["__pytest_meta"]["profile"]],
+            regions=[bucket["__pytest_meta"]["region"]],
+        ).values()[0]
         for bucket in s3_buckets()
     ]
 
 
 def s3_buckets_website():
     "http://botocore.readthedocs.io/en/latest/reference/services/s3.html#S3.Client.get_bucket_website"
-    empty_response = {'IndexDocument': None, 'ErrorDocument': None, 'RedirectAllRequestsTo': None}
+    empty_response = {
+        "IndexDocument": None,
+        "ErrorDocument": None,
+        "RedirectAllRequestsTo": None,
+    }
     return [
         website
         for bucket in s3_buckets()
-        for website in botocore_client
-        .get('s3',
-             'get_bucket_website',
-             [],
-             {'Bucket': bucket['Name']},
-             profiles=[bucket['__pytest_meta']['profile']],
-             regions=[bucket['__pytest_meta']['region']],
-             result_from_error=lambda e, call: empty_response)
-        .values()
+        for website in botocore_client.get(
+            "s3",
+            "get_bucket_website",
+            [],
+            {"Bucket": bucket["Name"]},
+            profiles=[bucket["__pytest_meta"]["profile"]],
+            regions=[bucket["__pytest_meta"]["region"]],
+            result_from_error=lambda e, call: empty_response,
+        ).values()
     ]
 
 
 def s3_buckets_policy():
     "http://botocore.readthedocs.io/en/latest/reference/services/s3.html#S3.Client.get_bucket_policy"
     return [
-        botocore_client
-        .get('s3',
-             'get_bucket_policy',
-             [],
-             {'Bucket': bucket['Name']},
-             profiles=[bucket['__pytest_meta']['profile']],
-             regions=[bucket['__pytest_meta']['region']],
-             result_from_error=lambda e, call: {'Policy': ''})
-        .extract_key('Policy')
+        botocore_client.get(
+            "s3",
+            "get_bucket_policy",
+            [],
+            {"Bucket": bucket["Name"]},
+            profiles=[bucket["__pytest_meta"]["profile"]],
+            regions=[bucket["__pytest_meta"]["region"]],
+            result_from_error=lambda e, call: {"Policy": ""},
+        )
+        .extract_key("Policy")
         .values()[0]
         for bucket in s3_buckets()
     ]

--- a/aws/s3/test_s3_bucket_cors_disabled.py
+++ b/aws/s3/test_s3_bucket_cors_disabled.py
@@ -1,21 +1,19 @@
 
 import pytest
 
-from aws.s3.resources import (
-    s3_buckets,
-    s3_buckets_cors_rules,
-)
+from aws.s3.resources import s3_buckets, s3_buckets_cors_rules
 
 
 @pytest.mark.s3
 @pytest.mark.parametrize(
-    ['s3_bucket', 's3_bucket_cors_rules'],
+    ["s3_bucket", "s3_bucket_cors_rules"],
     zip(s3_buckets(), s3_buckets_cors_rules()),
-    ids=lambda bucket: bucket['Name'])
+    ids=lambda bucket: bucket["Name"],
+)
 def test_s3_bucket_cors_disabled(s3_bucket, s3_bucket_cors_rules):
     """
     Disable sharing S3 bucket contents cross origin with CORS headers.
 
     http://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html
     """
-    assert s3_bucket_cors_rules is None, 'CORS enabled for {0[Name]}'.format(s3_bucket)
+    assert s3_bucket_cors_rules is None, "CORS enabled for {0[Name]}".format(s3_bucket)

--- a/aws/s3/test_s3_bucket_does_not_grant_all_principals_all_actions.py
+++ b/aws/s3/test_s3_bucket_does_not_grant_all_principals_all_actions.py
@@ -3,30 +3,21 @@ import json
 
 import pytest
 
-from aws.s3.resources import (
-    s3_buckets,
-    s3_buckets_policy,
-)
+from aws.s3.resources import s3_buckets, s3_buckets_policy
 
 
-STAR_ACTIONS = [
-    '*',
-    's3:*',
-    's3:delete*',
-    's3:put*',
-    's3:get*',
-    's3:list*',
-]
+STAR_ACTIONS = ["*", "s3:*", "s3:delete*", "s3:put*", "s3:get*", "s3:list*"]
 
 
 @pytest.mark.s3
 @pytest.mark.parametrize(
-    ['s3_bucket', 's3_bucket_policy'],
+    ["s3_bucket", "s3_bucket_policy"],
     zip(s3_buckets(), s3_buckets_policy()),
-    ids=lambda bucket: bucket['Name'])
+    ids=lambda bucket: bucket["Name"],
+)
 def test_s3_bucket_does_not_grant_all_principals_all_actions(
-        s3_bucket,
-        s3_bucket_policy):
+    s3_bucket, s3_bucket_policy
+):
     """
     Check policy does not allow all principals all actions on the S3 Bucket.
 
@@ -38,18 +29,24 @@ def test_s3_bucket_does_not_grant_all_principals_all_actions(
     * add conditions http://docs.aws.amazon.com/AmazonS3/latest/dev/amazon-s3-policy-keys.html
     """
     if not s3_bucket_policy:
-        pytest.skip('Bucket has no policy, which means it defaults to private.')
+        pytest.skip("Bucket has no policy, which means it defaults to private.")
         # https://docs.aws.amazon.com/config/latest/developerguide/s3-bucket-policy.html
 
     policy = json.loads(s3_bucket_policy)
 
-    for statement in policy['Statement']:
-        if 'Condition' in statement:
+    for statement in policy["Statement"]:
+        if "Condition" in statement:
             continue
 
-        actions = [statement['Action']] if isinstance(statement['Action'], str) else statement['Action']
+        actions = (
+            [statement["Action"]]
+            if isinstance(statement["Action"], str)
+            else statement["Action"]
+        )
         actions = [action.lower() for action in actions]
 
-        assert not (statement['Effect'] == 'Allow'
-                    and any(action in STAR_ACTIONS for action in actions)
-                    and 'Principal' == '*')
+        assert not (
+            statement["Effect"] == "Allow"
+            and any(action in STAR_ACTIONS for action in actions)
+            and "Principal" == "*"
+        )

--- a/aws/s3/test_s3_bucket_logging_enabled.py
+++ b/aws/s3/test_s3_bucket_logging_enabled.py
@@ -1,19 +1,19 @@
 
 import pytest
 
-from aws.s3.resources import (
-    s3_buckets,
-    s3_buckets_logging,
-)
+from aws.s3.resources import s3_buckets, s3_buckets_logging
 
 
 @pytest.mark.s3
 @pytest.mark.parametrize(
-    ['s3_bucket', 's3_bucket_logging_enabled'],
+    ["s3_bucket", "s3_bucket_logging_enabled"],
     zip(s3_buckets(), s3_buckets_logging()),
-    ids=lambda bucket: bucket['Name'])
+    ids=lambda bucket: bucket["Name"],
+)
 def test_s3_bucket_logging_enabled(s3_bucket, s3_bucket_logging_enabled):
     """
     Enable access logs for S3 buckets.
     """
-    assert s3_bucket_logging_enabled, 'Logging not enabled for {0[Name]}'.format(s3_bucket)
+    assert s3_bucket_logging_enabled, "Logging not enabled for {0[Name]}".format(
+        s3_bucket
+    )

--- a/aws/s3/test_s3_bucket_no_world_acl.py
+++ b/aws/s3/test_s3_bucket_no_world_acl.py
@@ -1,37 +1,33 @@
 
 import pytest
 
-from aws.s3.resources import (
-    s3_buckets,
-    s3_buckets_acls,
-)
+from aws.s3.resources import s3_buckets, s3_buckets_acls
 
 
 AWS_PREDEFINED_GROUPS = [
     # allow any AWS account to access the resource with a signed/authed request
-    'http://acs.amazonaws.com/groups/global/AuthenticatedUsers',
-
+    "http://acs.amazonaws.com/groups/global/AuthenticatedUsers",
     # allows anyone in the world access to the resource
-    'http://acs.amazonaws.com/groups/global/AllUsers',
+    "http://acs.amazonaws.com/groups/global/AllUsers",
 ]
 
 
 @pytest.mark.s3
 @pytest.mark.parametrize(
-    ['s3_bucket', 's3_bucket_acl'],
+    ["s3_bucket", "s3_bucket_acl"],
     zip(s3_buckets(), s3_buckets_acls()),
-    ids=lambda bucket: bucket['Name'])
-def test_s3_bucket_no_world_acl(s3_bucket,
-                                s3_bucket_acl):
+    ids=lambda bucket: bucket["Name"],
+)
+def test_s3_bucket_no_world_acl(s3_bucket, s3_bucket_acl):
     """
     Check S3 bucket does not allow global predefined AWS groups access.
 
     http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html
     """
-    for grant in s3_bucket_acl['Grants']:
-        grantee = grant['Grantee']
-        if 'URI' not in grantee:
-            pytest.skip('S3 Bucket ACL does not use URI.')
+    for grant in s3_bucket_acl["Grants"]:
+        grantee = grant["Grantee"]
+        if "URI" not in grantee:
+            pytest.skip("S3 Bucket ACL does not use URI.")
 
-        grantee_uri = grantee['URI']
+        grantee_uri = grantee["URI"]
         assert not any(grantee_uri.startswith(group) for group in AWS_PREDEFINED_GROUPS)

--- a/aws/s3/test_s3_bucket_versioning_enabled.py
+++ b/aws/s3/test_s3_bucket_versioning_enabled.py
@@ -1,22 +1,19 @@
 
 import pytest
 
-from aws.s3.resources import (
-    s3_buckets,
-    s3_buckets_versioning,
-)
+from aws.s3.resources import s3_buckets, s3_buckets_versioning
 
 
 @pytest.mark.s3
 @pytest.mark.parametrize(
-    ['s3_bucket', 's3_bucket_versioning'],
+    ["s3_bucket", "s3_bucket_versioning"],
     zip(s3_buckets(), s3_buckets_versioning()),
-    ids=lambda bucket: bucket['Name'])
-def test_s3_bucket_versioning_enabled(s3_bucket,
-                                      s3_bucket_versioning):
+    ids=lambda bucket: bucket["Name"],
+)
+def test_s3_bucket_versioning_enabled(s3_bucket, s3_bucket_versioning):
     """
     Enable restoring every version of every object in the S3 bucket to easily recover data.
 
     http://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html
     """
-    assert s3_bucket_versioning.get('Status', None) == 'Enabled'
+    assert s3_bucket_versioning.get("Status", None) == "Enabled"

--- a/aws/s3/test_s3_bucket_versioning_mfa_delete_enabled.py
+++ b/aws/s3/test_s3_bucket_versioning_mfa_delete_enabled.py
@@ -1,23 +1,20 @@
 
 import pytest
 
-from aws.s3.resources import (
-    s3_buckets,
-    s3_buckets_versioning,
-)
+from aws.s3.resources import s3_buckets, s3_buckets_versioning
 
 
 @pytest.mark.s3
 @pytest.mark.parametrize(
-    ['s3_bucket', 's3_bucket_versioning'],
+    ["s3_bucket", "s3_bucket_versioning"],
     zip(s3_buckets(), s3_buckets_versioning()),
-    ids=lambda bucket: bucket['Name'])
-def test_s3_bucket_versioning_mfa_delete_enabled(s3_bucket,
-                                                 s3_bucket_versioning):
+    ids=lambda bucket: bucket["Name"],
+)
+def test_s3_bucket_versioning_mfa_delete_enabled(s3_bucket, s3_bucket_versioning):
     """
     Enable MFA delete for versioned S3 buckets to prevent their accidental deletion.
     """
-    if s3_bucket_versioning.get('Status', None) != 'Enabled':
+    if s3_bucket_versioning.get("Status", None) != "Enabled":
         return pytest.skip()
 
-    assert s3_bucket_versioning.get('MFADelete', None) != 'Disabled'
+    assert s3_bucket_versioning.get("MFADelete", None) != "Disabled"

--- a/aws/s3/test_s3_bucket_web_hosting_disabled.py
+++ b/aws/s3/test_s3_bucket_web_hosting_disabled.py
@@ -1,22 +1,19 @@
 
 import pytest
 
-from aws.s3.resources import (
-    s3_buckets,
-    s3_buckets_website,
-)
+from aws.s3.resources import s3_buckets, s3_buckets_website
 
 
 @pytest.mark.s3
 @pytest.mark.parametrize(
-    ['s3_bucket', 's3_bucket_website'],
+    ["s3_bucket", "s3_bucket_website"],
     zip(s3_buckets(), s3_buckets_website()),
-    ids=lambda bucket: bucket['Name'])
-def test_s3_bucket_web_hosting_disabled(s3_bucket,
-                                        s3_bucket_website):
+    ids=lambda bucket: bucket["Name"],
+)
+def test_s3_bucket_web_hosting_disabled(s3_bucket, s3_bucket_website):
     """
     Disable hosting static site in the S3 bucket.
     """
-    assert not s3_bucket_website['IndexDocument']
-    assert not s3_bucket_website['ErrorDocument']
-    assert not s3_bucket_website['RedirectAllRequestsTo']
+    assert not s3_bucket_website["IndexDocument"]
+    assert not s3_bucket_website["ErrorDocument"]
+    assert not s3_bucket_website["RedirectAllRequestsTo"]

--- a/bin/auth/setup_gsuite.py
+++ b/bin/auth/setup_gsuite.py
@@ -4,18 +4,18 @@ from gsuite.client import (
     CREDENTIALS,
     get_credentials,
     get_credential_dir,
-    get_credential_path
+    get_credential_path,
 )
 
 from oauth2client import client
 from oauth2client import tools
 from oauth2client.file import Storage
 
-APPLICATION_NAME = 'pytest-services'
+APPLICATION_NAME = "pytest-services"
 
 
 def get_client_secret_file():
-    return os.path.join(get_credential_dir(), 'client_secret.json')
+    return os.path.join(get_credential_dir(), "client_secret.json")
 
 
 def get_or_create_credentials(credential_name, scopes):
@@ -25,7 +25,7 @@ def get_or_create_credentials(credential_name, scopes):
         flow = client.flow_from_clientsecrets(get_client_secret_file(), scopes)
         flow.user_agent = APPLICATION_NAME
         credentials = tools.run_flow(flow, store, None)
-        print('Storing credentials to ' + get_credential_path(credential_name))
+        print("Storing credentials to " + get_credential_path(credential_name))
     return credentials
 
 
@@ -34,5 +34,5 @@ def main():
         get_or_create_credentials(creds[0], creds[1])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/cache.py
+++ b/cache.py
@@ -30,18 +30,15 @@ def datetime_encode_set(self, key, value):
     try:
         path.dirpath().ensure_dir()
     except (py.error.EEXIST, py.error.EACCES):
-        self.config.warn(
-            code='I9', message='could not create cache path %s' % (path,)
-            )
+        self.config.warn(code="I9", message="could not create cache path %s" % (path,))
         return
     try:
-        f = path.open('w')
+        f = path.open("w")
     except py.error.ENOTDIR:
-        self.config.warn(
-            code='I9', message='cache could not write path %s' % (path,))
+        self.config.warn(code="I9", message="cache could not write path %s" % (path,))
     else:
         with f:
-            self.trace("cache-write %s: %r" % (key, value,))
+            self.trace("cache-write %s: %r" % (key, value))
             json.dump(value, f, indent=4, sort_keys=True, default=json_iso_datetimes)
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -20,37 +20,47 @@ heroku_client = None
 
 
 def pytest_addoption(parser):
-    parser.addoption('--aws-profiles',
-                     nargs='*',
-                     help='Set default AWS profiles to use. Defaults to the current AWS profile i.e. [None].')
+    parser.addoption(
+        "--aws-profiles",
+        nargs="*",
+        help="Set default AWS profiles to use. Defaults to the current AWS profile i.e. [None].",
+    )
 
-    parser.addoption('--gcp-project-id',
-                     type=str,
-                     help='Set GCP project to test. Required for GCP tests.')
+    parser.addoption(
+        "--gcp-project-id",
+        type=str,
+        help="Set GCP project to test. Required for GCP tests.",
+    )
 
     # While only used for Heroku at the moment, GitHub tests are soon to be
     # added, which will also need an "organization" option. Current plan is to
     # reuse this one.
-    parser.addoption('--organization',
-                     type=str,
-                     help='Set organization to test. Used for Heroku tests.')
+    parser.addoption(
+        "--organization",
+        type=str,
+        help="Set organization to test. Used for Heroku tests.",
+    )
 
-    parser.addoption('--debug-calls',
-                     action='store_true',
-                     help='Log API calls. Requires -s')
+    parser.addoption(
+        "--debug-calls", action="store_true", help="Log API calls. Requires -s"
+    )
 
-    parser.addoption('--debug-cache',
-                     action='store_true',
-                     help='Log whether API calls hit the cache. Requires -s')
+    parser.addoption(
+        "--debug-cache",
+        action="store_true",
+        help="Log whether API calls hit the cache. Requires -s",
+    )
 
-    parser.addoption('--offline',
-                     action='store_true',
-                     default=False,
-                     help='Instruct service clients to return empty lists and not make HTTP requests.')
+    parser.addoption(
+        "--offline",
+        action="store_true",
+        default=False,
+        help="Instruct service clients to return empty lists and not make HTTP requests.",
+    )
 
-    parser.addoption('--config',
-                     type=argparse.FileType('r'),
-                     help='Path to the config file.')
+    parser.addoption(
+        "--config", type=argparse.FileType("r"), help="Path to the config file."
+    )
 
 
 def pytest_configure(config):
@@ -62,38 +72,44 @@ def pytest_configure(config):
     # monkeypatch cache.set to serialize datetime.datetime's
     patch_cache_set(config)
 
-    profiles = config.getoption('--aws-profiles')
-    project_id = config.getoption('--gcp-project-id')
-    organization = config.getoption('--organization')
+    profiles = config.getoption("--aws-profiles")
+    project_id = config.getoption("--gcp-project-id")
+    organization = config.getoption("--organization")
 
     botocore_client = BotocoreClient(
         profiles=profiles,
         cache=config.cache,
-        debug_calls=config.getoption('--debug-calls'),
-        debug_cache=config.getoption('--debug-cache'),
-        offline=config.getoption('--offline'))
+        debug_calls=config.getoption("--debug-calls"),
+        debug_cache=config.getoption("--debug-cache"),
+        offline=config.getoption("--offline"),
+    )
 
     gcp_client = GCPClient(
         project_id=project_id,
         cache=config.cache,
-        debug_calls=config.getoption('--debug-calls'),
-        debug_cache=config.getoption('--debug-cache'),
-        offline=config.getoption('--offline'))
+        debug_calls=config.getoption("--debug-calls"),
+        debug_cache=config.getoption("--debug-cache"),
+        offline=config.getoption("--offline"),
+    )
 
     heroku_client = HerokuAdminClient(
         organization=organization,
         # cache=config.cache,
         cache=None,
-        debug_calls=config.getoption('--debug-calls'),
-        debug_cache=config.getoption('--debug-cache'),
-        offline=config.getoption('--offline'))
+        debug_calls=config.getoption("--debug-calls"),
+        debug_cache=config.getoption("--debug-cache"),
+        offline=config.getoption("--offline"),
+    )
 
-    config.custom_config = custom_config.CustomConfig(config.getoption('--config'))
+    config.custom_config = custom_config.CustomConfig(config.getoption("--config"))
 
-    if any(x for x in config.args if 'gsuite' in x):
-        gsuite_client = GsuiteClient(domain=config.custom_config.gsuite.domain, offline=config.getoption('--offline'))
+    if any(x for x in config.args if "gsuite" in x):
+        gsuite_client = GsuiteClient(
+            domain=config.custom_config.gsuite.domain,
+            offline=config.getoption("--offline"),
+        )
     else:
-        gsuite_client = GsuiteClient(domain='', offline=True)
+        gsuite_client = GsuiteClient(domain="", offline=True)
 
 
 @pytest.fixture
@@ -112,20 +128,24 @@ def pytest_runtest_setup(item):
 
 
 def get_node_markers(node):
-    return {k: v for k, v in node.keywords.items() if isinstance(v, (MarkDecorator, MarkInfo))}
+    return {
+        k: v
+        for k, v in node.keywords.items()
+        if isinstance(v, (MarkDecorator, MarkInfo))
+    }
 
 
 METADATA_KEYS = [
-    'DBInstanceArn',
-    'DBInstanceIdentifier',
-    'GroupId',
-    'OwnerId',
-    'TagList',
-    'Tags',
-    'UserName',
-    'VolumeId',
-    'VpcId',
-    '__pytest_meta',
+    "DBInstanceArn",
+    "DBInstanceIdentifier",
+    "GroupId",
+    "OwnerId",
+    "TagList",
+    "Tags",
+    "UserName",
+    "VolumeId",
+    "VpcId",
+    "__pytest_meta",
 ]
 
 
@@ -147,27 +167,27 @@ def get_metadata_from_funcargs(funcargs):
 
 def serialize_marker(marker):
     if isinstance(marker, (MarkDecorator, MarkInfo)):
-        args = ['...skipped...'] if marker.name == 'parametrize' else marker.args
-        kwargs = ['...skipped...'] if marker.name == 'parametrize' else marker.kwargs
-        return {
-            'name': marker.name,
-            'args': args,
-            'kwargs': kwargs,
-        }
+        args = ["...skipped..."] if marker.name == "parametrize" else marker.args
+        kwargs = ["...skipped..."] if marker.name == "parametrize" else marker.kwargs
+        return {"name": marker.name, "args": args, "kwargs": kwargs}
     else:
-        raise NotImplementedError('Unexpected Marker type %s' % repr(marker))
+        raise NotImplementedError("Unexpected Marker type %s" % repr(marker))
 
 
 def get_outcome_and_reason(report, markers, call):
-    xfail = 'xfail' in markers
+    xfail = "xfail" in markers
     xpass = report.passed and xfail
 
-    if call.excinfo and not isinstance(call.excinfo, AssertionError) and isinstance(call.excinfo, Exception):
-        return 'errored', call.excinfo
+    if (
+        call.excinfo
+        and not isinstance(call.excinfo, AssertionError)
+        and isinstance(call.excinfo, Exception)
+    ):
+        return "errored", call.excinfo
     elif xpass:
-        return 'xpassed', markers['xfail']['kwargs'].get('reason', None)
+        return "xpassed", markers["xfail"]["kwargs"].get("reason", None)
     elif xfail:
-        return 'xfailed', markers['xfail']['kwargs'].get('reason', None)
+        return "xfailed", markers["xfail"]["kwargs"].get("reason", None)
     else:
         return report.outcome, None  # passed, failed, skipped
 
@@ -181,7 +201,9 @@ def clean_docstring(docstr):
     >>> clean_docstring("foo bar")
     'foo bar'
     """
-    return " ".join([word for word in docstr.replace("\n", " ").strip().split(" ") if word != ""])
+    return " ".join(
+        [word for word in docstr.replace("\n", " ").strip().split(" ") if word != ""]
+    )
 
 
 @pytest.mark.hookwrapper
@@ -190,14 +212,17 @@ def pytest_runtest_makereport(item, call):
     report = outcome.get_result()
 
     # only add this during call instead of during any stage
-    if report.when == 'call' and not isinstance(item, DoctestItem):
+    if report.when == "call" and not isinstance(item, DoctestItem):
         metadata = get_metadata_from_funcargs(item.funcargs)
         markers = {k: serialize_marker(v) for (k, v) in get_node_markers(item).items()}
-        severity = markers.get('severity', None) and markers.get('severity')['args'][0]
-        regression = markers.get('regression', None) and markers.get('regression')['args'][0]
+        severity = markers.get("severity", None) and markers.get("severity")["args"][0]
+        regression = (
+            markers.get("regression", None) and markers.get("regression")["args"][0]
+        )
         outcome, reason = get_outcome_and_reason(report, markers, call)
-        rationale = markers.get('rationale', None) and \
-            clean_docstring(markers.get('rationale')['args'][0])
+        rationale = markers.get("rationale", None) and clean_docstring(
+            markers.get("rationale")["args"][0]
+        )
         description = item._obj.__doc__ and clean_docstring(item._obj.__doc__)
 
         # add json metadata

--- a/custom_config.py
+++ b/custom_config.py
@@ -10,16 +10,15 @@ import regressions
 
 
 class CustomConfig:
-
     def __init__(self, config_fd):
         parsed_config = {}
         if config_fd is not None:
             parsed_config = yaml.load(config_fd)
-        self.aws = AWSConfig(parsed_config.get('aws', {}))
-        self.gsuite = GSuiteConfig(parsed_config.get('gsuite', {}))
-        self.exemptions = exemptions.load(parsed_config.get('exemptions'))
-        self.severities = severity.load(parsed_config.get('severities'))
-        self.regressions = regressions.load(parsed_config.get('regressions'))
+        self.aws = AWSConfig(parsed_config.get("aws", {}))
+        self.gsuite = GSuiteConfig(parsed_config.get("gsuite", {}))
+        self.exemptions = exemptions.load(parsed_config.get("exemptions"))
+        self.severities = severity.load(parsed_config.get("severities"))
+        self.regressions = regressions.load(parsed_config.get("regressions"))
 
     def add_markers(self, item):
         severity.add_severity_marker(item)
@@ -28,70 +27,72 @@ class CustomConfig:
 
 
 class CustomConfigMixin:
-
     def __init__(self, config):
-        self.user_is_inactive = config.get('user_is_inactive', {})
+        self.user_is_inactive = config.get("user_is_inactive", {})
 
     def no_activity_since(self):
-        no_activity_since = self._parse_user_is_inactive_relative_time('no_activity_since')
+        no_activity_since = self._parse_user_is_inactive_relative_time(
+            "no_activity_since"
+        )
         if no_activity_since is None:
-            return datetime.now(timezone.utc)-relativedelta(years=+1)
+            return datetime.now(timezone.utc) - relativedelta(years=+1)
         return no_activity_since
 
     def created_after(self):
-        created_after = self._parse_user_is_inactive_relative_time('created_after')
+        created_after = self._parse_user_is_inactive_relative_time("created_after")
         if created_after is None:
-            return datetime.now(timezone.utc)-relativedelta(weeks=+1)
+            return datetime.now(timezone.utc) - relativedelta(weeks=+1)
         return created_after
 
     def _parse_user_is_inactive_relative_time(self, key):
         if self.user_is_inactive.get(key) is None:
             return None
 
-        return datetime.now(timezone.utc)-relativedelta(
-            years=+self.user_is_inactive[key].get('years', 0),
-            months=+self.user_is_inactive[key].get('months', 0),
-            weeks=+self.user_is_inactive[key].get('weeks', 0)
+        return datetime.now(timezone.utc) - relativedelta(
+            years=+self.user_is_inactive[key].get("years", 0),
+            months=+self.user_is_inactive[key].get("months", 0),
+            weeks=+self.user_is_inactive[key].get("weeks", 0),
         )
 
 
 class AWSConfig(CustomConfigMixin):
-
     def __init__(self, config):
-        self.required_tags = frozenset(config.get('required_tags', []))
-        self.whitelisted_ports_global = set(config.get('whitelisted_ports_global', []))
-        self.whitelisted_ports = config.get('whitelisted_ports', [])
-        self.access_key_expires_after = config.get('access_key_expires_after', None)
+        self.required_tags = frozenset(config.get("required_tags", []))
+        self.whitelisted_ports_global = set(config.get("whitelisted_ports_global", []))
+        self.whitelisted_ports = config.get("whitelisted_ports", [])
+        self.access_key_expires_after = config.get("access_key_expires_after", None)
         super().__init__(config)
 
     def get_whitelisted_ports(self, test_id):
-        return self.get_whitelisted_ports_from_test_id(test_id) | self.whitelisted_ports_global
+        return (
+            self.get_whitelisted_ports_from_test_id(test_id)
+            | self.whitelisted_ports_global
+        )
 
     def get_whitelisted_ports_from_test_id(self, test_id):
         for rule in self.whitelisted_ports:
-            if rule['test_param_id'].startswith('*'):
-                substring = rule['test_param_id'][1:]
+            if rule["test_param_id"].startswith("*"):
+                substring = rule["test_param_id"][1:]
                 if re.search(substring, test_id):
-                    return set(rule['ports'])
+                    return set(rule["ports"])
 
-            if test_id == rule['test_param_id']:
-                return set(rule['ports'])
+            if test_id == rule["test_param_id"]:
+                return set(rule["ports"])
 
         return set([])
 
     def get_access_key_expiration_date(self):
         if self.access_key_expires_after is None:
-            return datetime.now(timezone.utc)-relativedelta(years=+1)
+            return datetime.now(timezone.utc) - relativedelta(years=+1)
 
-        return datetime.now(timezone.utc)-relativedelta(
-            years=+self.access_key_expires_after.get('years', 0),
-            months=+self.access_key_expires_after.get('months', 0),
-            weeks=+self.access_key_expires_after.get('weeks', 0)
+        return datetime.now(timezone.utc) - relativedelta(
+            years=+self.access_key_expires_after.get("years", 0),
+            months=+self.access_key_expires_after.get("months", 0),
+            weeks=+self.access_key_expires_after.get("weeks", 0),
         )
 
 
 class GSuiteConfig(CustomConfigMixin):
-
     def __init__(self, config):
-        self.domain = config.get('domain', '')
+        self.domain = config.get("domain", "")
         super().__init__(config)

--- a/exemptions.py
+++ b/exemptions.py
@@ -90,20 +90,22 @@ def load(rules):
         return processed_rules
 
     for rule in rules:
-        test_name, test_id = rule['test_name'], rule['test_param_id']
-        expiration, reason = rule['expiration_day'], rule['reason']
+        test_name, test_id = rule["test_name"], rule["test_param_id"]
+        expiration, reason = rule["expiration_day"], rule["reason"]
 
         if expiration < date.today():
             warnings.warn(
-                'Exemptions: test_name: {} | test_id: {} | Skipping rule with expiration day in the past {!r}'
-                .format(test_name, test_id, expiration)
+                "Exemptions: test_name: {} | test_id: {} | Skipping rule with expiration day in the past {!r}".format(
+                    test_name, test_id, expiration
+                )
             )
             continue
 
         if test_id in processed_rules[test_name]:
             warnings.warn(
-                'Exemptions: test_name: {} | test_id: {} | Skipping duplicate test name and ID'
-                .format(test_name, test_id)
+                "Exemptions: test_name: {} | test_id: {} | Skipping duplicate test name and ID".format(
+                    test_name, test_id
+                )
             )
             continue
 
@@ -116,8 +118,12 @@ def add_xfail_marker(item):
     """
     Adds xfail markers for test names and ids specified in the exemptions conf.
     """
-    if not item.get_marker('parametrize'):
-        warnings.warn('Skipping exemption checks for test without resource name {!r}'.format(item.name))
+    if not item.get_marker("parametrize"):
+        warnings.warn(
+            "Skipping exemption checks for test without resource name {!r}".format(
+                item.name
+            )
+        )
         return
 
     test_exemptions = item.config.custom_config.exemptions.get(item.originalname, None)
@@ -126,13 +132,19 @@ def add_xfail_marker(item):
     if test_exemptions:
         # Check for any substring matchers
         for exemption_test_id in test_exemptions:
-            if exemption_test_id.startswith('*'):
+            if exemption_test_id.startswith("*"):
                 substring = exemption_test_id[1:]
                 if re.search(substring, test_id):
                     expiration, reason = test_exemptions[exemption_test_id]
-                    item.add_marker(pytest.mark.xfail(reason=reason, strict=True, expiration=expiration))
+                    item.add_marker(
+                        pytest.mark.xfail(
+                            reason=reason, strict=True, expiration=expiration
+                        )
+                    )
                     return
 
         if test_id in test_exemptions:
             expiration, reason = test_exemptions[test_id]
-            item.add_marker(pytest.mark.xfail(reason=reason, strict=True, expiration=expiration))
+            item.add_marker(
+                pytest.mark.xfail(reason=reason, strict=True, expiration=expiration)
+            )

--- a/gcp/compute/helpers.py
+++ b/gcp/compute/helpers.py
@@ -1,5 +1,3 @@
-
-
 def does_firewall_open_all_ports_to_all(firewall):
     """
     Returns True if firewall has a rule to open all ports to all. Excludes ICMP.
@@ -13,15 +11,18 @@ def does_firewall_open_all_ports_to_all(firewall):
     >>> does_firewall_open_all_ports_to_all({'sourceRanges': ['0.0.0.0/0'], 'allowed': [{'ports': '0-65535'}]})
     True
     """
-    if firewall.get("sourceRanges") is None or "0.0.0.0/0" not in firewall['sourceRanges']:
+    if (
+        firewall.get("sourceRanges") is None
+        or "0.0.0.0/0" not in firewall["sourceRanges"]
+    ):
         return False
 
-    for rule in firewall.get('allowed'):
-        if rule.get('IPProtocol', '') == 'icmp':
+    for rule in firewall.get("allowed"):
+        if rule.get("IPProtocol", "") == "icmp":
             continue
-        if not rule.get('ports'):
+        if not rule.get("ports"):
             return True
-        if rule.get('ports') == '0-65535':
+        if rule.get("ports") == "0-65535":
             return True
 
     return False
@@ -29,4 +30,4 @@ def does_firewall_open_all_ports_to_all(firewall):
 
 def firewall_id(firewall):
     """A getter fn for test ids for Firewalls"""
-    return "{} {}".format(firewall['id'], firewall['name'])
+    return "{} {}".format(firewall["id"], firewall["name"])

--- a/gcp/compute/resources.py
+++ b/gcp/compute/resources.py
@@ -15,16 +15,21 @@ def instances():
 
 def networks_with_instances():
     for network in networks():
-        network['instances'] = []
+        network["instances"] = []
         for instance in instances():
-            if network['selfLink'] in [interface['network'] for interface in instance['networkInterfaces']]:
-                network['instances'].append(instance)
-        if len(network['instances']):
+            if network["selfLink"] in [
+                interface["network"] for interface in instance["networkInterfaces"]
+            ]:
+                network["instances"].append(instance)
+        if len(network["instances"]):
             yield network
 
 
 def in_use_firewalls():
     for firewall in firewalls():
         for network in networks_with_instances():
-            if network['selfLink'] == firewall['network'] and len(network['instances']) > 0:
-                    yield firewall
+            if (
+                network["selfLink"] == firewall["network"]
+                and len(network["instances"]) > 0
+            ):
+                yield firewall

--- a/gcp/compute/test_firewall_opens_all_ports_to_all.py
+++ b/gcp/compute/test_firewall_opens_all_ports_to_all.py
@@ -1,16 +1,11 @@
 import pytest
 
-from gcp.compute.helpers import (
-    does_firewall_open_all_ports_to_all,
-    firewall_id,
-)
+from gcp.compute.helpers import does_firewall_open_all_ports_to_all, firewall_id
 from gcp.compute.resources import in_use_firewalls
 
 
 @pytest.mark.gcp_compute
-@pytest.mark.parametrize('firewall',
-                         in_use_firewalls(),
-                         ids=firewall_id)
+@pytest.mark.parametrize("firewall", in_use_firewalls(), ids=firewall_id)
 def test_firewall_opens_all_ports_to_all(firewall):
     """Checks if firewall opens all ports to all IPs"""
     assert not does_firewall_open_all_ports_to_all(firewall)

--- a/gcp/iam/helpers.py
+++ b/gcp/iam/helpers.py
@@ -5,6 +5,8 @@ def is_service_account_key_old(service_account_key):
     """
     Tests whether a service account key is older than 90 days.
     """
-    creation_date = datetime.datetime.strptime(service_account_key['validAfterTime'][:10], "%Y-%m-%d")
+    creation_date = datetime.datetime.strptime(
+        service_account_key["validAfterTime"][:10], "%Y-%m-%d"
+    )
     # TODO: Make configurable
-    return (creation_date > datetime.datetime.now() - datetime.timedelta(days=90))
+    return creation_date > datetime.datetime.now() - datetime.timedelta(days=90)

--- a/gcp/iam/resources.py
+++ b/gcp/iam/resources.py
@@ -6,7 +6,7 @@ def service_accounts():
         "iam",
         "projects.serviceAccounts",
         results_key="accounts",
-        call_kwargs={'name': 'projects/'+gcp_client.get_project_id()}
+        call_kwargs={"name": "projects/" + gcp_client.get_project_id()},
     )
 
 
@@ -15,7 +15,7 @@ def service_account_keys(service_account):
         "iam",
         "projects.serviceAccounts.keys",
         results_key="keys",
-        call_kwargs={'name': service_account['name']}
+        call_kwargs={"name": service_account["name"]},
     )
 
 

--- a/gcp/iam/test_service_account_key_is_old.py
+++ b/gcp/iam/test_service_account_key_is_old.py
@@ -5,9 +5,9 @@ from gcp.iam.helpers import is_service_account_key_old
 
 
 @pytest.mark.gcp_iam
-@pytest.mark.parametrize('service_account_key',
-                         all_service_account_keys(),
-                         ids=lambda key: key['name'])
+@pytest.mark.parametrize(
+    "service_account_key", all_service_account_keys(), ids=lambda key: key["name"]
+)
 def test_service_account_key_is_old(service_account_key):
     """Tests if the Service Account Key is older than 90 days"""
     assert is_service_account_key_old(service_account_key)

--- a/gcp/sql/test_sql_instance_automatic_backup_enabled.py
+++ b/gcp/sql/test_sql_instance_automatic_backup_enabled.py
@@ -4,11 +4,15 @@ from gcp.sql.resources import instances
 
 
 @pytest.mark.gcp_sql
-@pytest.mark.parametrize('sql_instance',
-                         instances(),
-                         ids=lambda instance: instance['name'])
+@pytest.mark.parametrize(
+    "sql_instance", instances(), ids=lambda instance: instance["name"]
+)
 def test_sql_instance_automatic_backup_enabled(sql_instance):
     """Test CloudSQL Instance has Automatic Backup Enabled"""
-    assert sql_instance.get('settings').get('backupConfiguration').get('enabled')
-    if 'MYSQL' in sql_instance.get('databaseVersion'):
-        assert sql_instance.get('settings').get('backupConfiguration').get('binaryLogEnabled')
+    assert sql_instance.get("settings").get("backupConfiguration").get("enabled")
+    if "MYSQL" in sql_instance.get("databaseVersion"):
+        assert (
+            sql_instance.get("settings")
+            .get("backupConfiguration")
+            .get("binaryLogEnabled")
+        )

--- a/gcp/sql/test_sql_instance_ssl_required.py
+++ b/gcp/sql/test_sql_instance_ssl_required.py
@@ -4,9 +4,9 @@ from gcp.sql.resources import instances
 
 
 @pytest.mark.gcp_sql
-@pytest.mark.parametrize('sql_instance',
-                         instances(),
-                         ids=lambda instance: instance['name'])
+@pytest.mark.parametrize(
+    "sql_instance", instances(), ids=lambda instance: instance["name"]
+)
 def test_sql_instance_ssl_required(sql_instance):
     """Test CloudSQL Instance requires SSL"""
-    assert sql_instance.get('settings').get('ipConfiguration').get('requireSsl')
+    assert sql_instance.get("settings").get("ipConfiguration").get("requireSsl")

--- a/gsuite/admin/helpers.py
+++ b/gsuite/admin/helpers.py
@@ -5,4 +5,4 @@ def user_is_inactive(user, no_activity_since):
     """
     Compares the lastLoginTime with no_activity_since.
     """
-    return parse(user['lastLoginTime']) > no_activity_since
+    return parse(user["lastLoginTime"]) > no_activity_since

--- a/gsuite/admin/test_admin_user_is_inactive.py
+++ b/gsuite/admin/test_admin_user_is_inactive.py
@@ -10,7 +10,7 @@ def no_activity_since(pytestconfig):
 
 
 @pytest.mark.gsuite_admin
-@pytest.mark.parametrize('user', list_users(), ids=lambda u: u['primaryEmail'])
+@pytest.mark.parametrize("user", list_users(), ids=lambda u: u["primaryEmail"])
 def test_admin_user_is_inactive(user, no_activity_since):
     """Tests whether user is active by checking lastLoginTime"""
     assert user_is_inactive(user, no_activity_since)

--- a/gsuite/client.py
+++ b/gsuite/client.py
@@ -4,22 +4,25 @@ import httplib2
 from apiclient import discovery
 from oauth2client.file import Storage
 
-ADMIN_DIRECTORY_USER_READONLY = 'admin-directory-user-readonly'
+ADMIN_DIRECTORY_USER_READONLY = "admin-directory-user-readonly"
 CREDENTIALS = [
-    (ADMIN_DIRECTORY_USER_READONLY, 'https://www.googleapis.com/auth/admin.directory.user.readonly'),
+    (
+        ADMIN_DIRECTORY_USER_READONLY,
+        "https://www.googleapis.com/auth/admin.directory.user.readonly",
+    )
 ]
 
 
 def get_credential_dir():
-    home_dir = os.path.expanduser('~')
-    credential_dir = os.path.join(home_dir, '.credentials')
+    home_dir = os.path.expanduser("~")
+    credential_dir = os.path.join(home_dir, ".credentials")
     if not os.path.exists(credential_dir):
         os.makedirs(credential_dir)
     return credential_dir
 
 
 def get_credential_path(credential_name):
-    return os.path.join(get_credential_dir(), credential_name+'.json')
+    return os.path.join(get_credential_dir(), credential_name + ".json")
 
 
 def get_credentials(credential_name):
@@ -28,7 +31,6 @@ def get_credentials(credential_name):
 
 
 class GsuiteClient:
-
     def __init__(self, domain, offline):
         self.domain = domain
         self.offline = offline
@@ -39,7 +41,7 @@ class GsuiteClient:
     def build_directory_client(self):
         credentials = get_credentials(ADMIN_DIRECTORY_USER_READONLY)
         http = credentials.authorize(httplib2.Http())
-        return discovery.build('admin', 'directory_v1', http=http)
+        return discovery.build("admin", "directory_v1", http=http)
 
     def list_users(self):
         if self.offline:

--- a/heroku/client.py
+++ b/heroku/client.py
@@ -13,23 +13,30 @@ def cache_key(organization, method, *args, **kwargs):
     ... )
     'pytest_heroku:organization_name:method_name:arg1,arg2:kwarg1=True.json'
     """
-    return ':'.join([
-        'pytest_heroku',
-        str(organization),
-        str(method),
-        ','.join(args),
-        ','.join('{}={}'.format(k, v) for (k, v) in kwargs.items()),
-    ]) + '.json'
+    return (
+        ":".join(
+            [
+                "pytest_heroku",
+                str(organization),
+                str(method),
+                ",".join(args),
+                ",".join("{}={}".format(k, v) for (k, v) in kwargs.items()),
+            ]
+        )
+        + ".json"
+    )
 
 
-def get_heroku_resource(organization,
-                        method_name,
-                        call_args,
-                        call_kwargs,
-                        cache=None,
-                        result_from_error=None,
-                        debug_calls=False,
-                        debug_cache=False):
+def get_heroku_resource(
+    organization,
+    method_name,
+    call_args,
+    call_kwargs,
+    cache=None,
+    result_from_error=None,
+    debug_calls=False,
+    debug_cache=False,
+):
     """
     Fetches and return final data
 
@@ -38,7 +45,7 @@ def get_heroku_resource(organization,
         - cache all apps of member
     """
     if debug_calls:
-        print('calling', method_name, 'on', organization)
+        print("calling", method_name, "on", organization)
 
     result = None
     if cache is not None:
@@ -46,22 +53,17 @@ def get_heroku_resource(organization,
         result = cache.get(ckey, None)
 
         if debug_cache and result is not None:
-            print('found cached value for', ckey)
+            print("found cached value for", ckey)
 
     if result is None:
         # convert from defaultdict with values as sets
-        users = {k: list(v) for k, v in
-                 find_users_missing_2fa(organization).items()}
-        apps = {k: list(v) for k, v in
-                find_affected_apps(users, organization).items()}
-        result = [{
-            HerokuDataSets.ROLE_USER: users,
-            HerokuDataSets.APP_USER: apps,
-        }]
+        users = {k: list(v) for k, v in find_users_missing_2fa(organization).items()}
+        apps = {k: list(v) for k, v in find_affected_apps(users, organization).items()}
+        result = [{HerokuDataSets.ROLE_USER: users, HerokuDataSets.APP_USER: apps}]
 
         if cache is not None:
             if debug_cache:
-                print('setting cache value for', ckey)
+                print("setting cache value for", ckey)
 
             cache.set(ckey, result)
 
@@ -72,7 +74,7 @@ class HerokuDataSets:
     # We use an IntEnum so keys can be ordered, which is done deep in some
     # libraries when we use the enums as dict keys
     ROLE_USER = 1  # tuple of (role, user)
-    APP_USER = 2   # tuple of (app, user)
+    APP_USER = 2  # tuple of (app, user)
 
 
 class HerokuAdminClient:
@@ -80,12 +82,7 @@ class HerokuAdminClient:
     # ensure we have access from instance
     data_set_names = HerokuDataSets
 
-    def __init__(self,
-                 organization,
-                 cache,
-                 debug_calls,
-                 debug_cache,
-                 offline):
+    def __init__(self, organization, cache, debug_calls, debug_cache, offline):
         self.organization = organization
         self.cache = cache
 
@@ -95,25 +92,30 @@ class HerokuAdminClient:
 
         self.results = []
 
-    def get(self,
-            method_name,
-            call_args,
-            call_kwargs,
-            result_from_error=None,
-            do_not_cache=False):
+    def get(
+        self,
+        method_name,
+        call_args,
+        call_kwargs,
+        result_from_error=None,
+        do_not_cache=False,
+    ):
 
         if self.offline:
             self.results = []
         else:
-            self.results = list(get_heroku_resource(
-                self.organization,
-                method_name,
-                call_args,
-                call_kwargs,
-                cache=self.cache if not do_not_cache else None,
-                result_from_error=result_from_error,
-                debug_calls=self.debug_calls,
-                debug_cache=self.debug_cache))
+            self.results = list(
+                get_heroku_resource(
+                    self.organization,
+                    method_name,
+                    call_args,
+                    call_kwargs,
+                    cache=self.cache if not do_not_cache else None,
+                    result_from_error=result_from_error,
+                    debug_calls=self.debug_calls,
+                    debug_cache=self.debug_cache,
+                )
+            )
 
         return self
 

--- a/heroku/resources.py
+++ b/heroku/resources.py
@@ -5,8 +5,7 @@ from conftest import heroku_client
 def users_no_2fa():
     """
     """
-    raw = heroku_client.get(
-        'all', [], {})
+    raw = heroku_client.get("all", [], {})
     just_key = raw.extract_key(heroku_client.data_set_names.ROLE_USER, [])
     datum = just_key.results or [{}]
     return datum
@@ -20,8 +19,7 @@ def users_no_2fa():
 def app_users_no_2fa():
     """
     """
-    raw = heroku_client.get(
-        'all', [], {})
+    raw = heroku_client.get("all", [], {})
     just_key = raw.extract_key(heroku_client.data_set_names.APP_USER, [])
     datum = just_key.results or [{}]
     return datum

--- a/heroku/test_heroku_2fa.py
+++ b/heroku/test_heroku_2fa.py
@@ -32,16 +32,18 @@ def affected_apps():
 
 @pytest.fixture
 def role_user():
-    result = [(role, email) for role, emails in affected_users().items()
-              for email in emails]
+    result = [
+        (role, email) for role, emails in affected_users().items() for email in emails
+    ]
     # assert len(result) > 0
     return result
 
 
 @pytest.fixture
 def app_user():
-    result = [(app, email) for app, emails in affected_apps().items()
-              for email in emails]
+    result = [
+        (app, email) for app, emails in affected_apps().items() for email in emails
+    ]
     # assert len(result) > 0
     return result
 
@@ -54,12 +56,12 @@ def app_user():
 
 # code for heroku/conftest.py END
 @pytest.mark.heroku
-@pytest.mark.parametrize('role_user', role_user())
+@pytest.mark.parametrize("role_user", role_user())
 def test_users_have_2fa_enabled(role_user):
     assert not role_user
 
 
 @pytest.mark.heroku
-@pytest.mark.parametrize('app_user', app_user())
+@pytest.mark.parametrize("app_user", app_user())
 def test_no_apps_impacted(app_user):
     assert not app_user

--- a/pagerduty/test_user_has_escalation_policy.py
+++ b/pagerduty/test_user_has_escalation_policy.py
@@ -6,7 +6,7 @@ import pytest
 import pygerduty.v2
 
 
-PD_RO_KEY = os.environ.get('pagerdutyRoKey', None)
+PD_RO_KEY = os.environ.get("pagerdutyRoKey", None)
 
 
 def pd_client():
@@ -29,20 +29,22 @@ def pd_users_escalation_policies():
         return []
 
     return [
-        pager.escalation_policies.list(user_ids=[user['id']])
-        for user in pd_users()
+        pager.escalation_policies.list(user_ids=[user["id"]]) for user in pd_users()
     ]
 
 
 @pytest.mark.pagerduty
-@pytest.mark.skipif(lambda: not PD_RO_KEY,
-                    reason='Env var "pagerdutyRoKey" of Pagerduty API key not found.')
-@pytest.mark.parametrize([
-    'pd_user',
-    'pd_user_escalation_policy',
-], zip(pd_users(), pd_users_escalation_policies()))
-def test_user_has_ooh_escalation_policy(
-        pd_user,
-        pd_user_escalation_policy):
-    assert pd_user_escalation_policy, \
-      '{} does not have an out of hours escalation policy in Pagerduty'.format(pd_user)
+@pytest.mark.skipif(
+    lambda: not PD_RO_KEY,
+    reason='Env var "pagerdutyRoKey" of Pagerduty API key not found.',
+)
+@pytest.mark.parametrize(
+    ["pd_user", "pd_user_escalation_policy"],
+    zip(pd_users(), pd_users_escalation_policies()),
+)
+def test_user_has_ooh_escalation_policy(pd_user, pd_user_escalation_policy):
+    assert (
+        pd_user_escalation_policy
+    ), "{} does not have an out of hours escalation policy in Pagerduty".format(
+        pd_user
+    )

--- a/regressions.py
+++ b/regressions.py
@@ -73,12 +73,17 @@ def load(rules):
         return processed_rules
 
     for rule in rules:
-        test_name, test_id, comment = rule['test_name'], rule['test_param_id'], rule['comment']
+        test_name, test_id, comment = (
+            rule["test_name"],
+            rule["test_param_id"],
+            rule["comment"],
+        )
 
         if test_id in processed_rules[test_name]:
             warnings.warn(
-                'Regressions: test_name: {} | test_id: {} | Skipping duplicate test name and ID'
-                .format(test_name, test_id)
+                "Regressions: test_name: {} | test_id: {} | Skipping duplicate test name and ID".format(
+                    test_name, test_id
+                )
             )
             continue
 
@@ -92,16 +97,22 @@ def add_regression_marker(item):
     """
     Adds regression markers as specified in the config file.
     """
-    if not item.get_marker('parametrize'):
-        warnings.warn('Skipping regression checks for test without resource name {!r}'.format(item.name))
+    if not item.get_marker("parametrize"):
+        warnings.warn(
+            "Skipping regression checks for test without resource name {!r}".format(
+                item.name
+            )
+        )
         return
 
-    test_regressions = item.config.custom_config.regressions.get(item.originalname, None)
+    test_regressions = item.config.custom_config.regressions.get(
+        item.originalname, None
+    )
     test_id = item._genid
 
     if test_regressions:
         for regression_test_id in test_regressions:
-            if regression_test_id.startswith('*'):
+            if regression_test_id.startswith("*"):
                 substring = regression_test_id[1:]
                 if re.search(substring, test_id):
                     comment = test_regressions[regression_test_id]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 botocore==1.8.24
 coverage==4.5
-flake8==3.5.0
+black==18.6b4
 google_api_python_client==1.6.1
 PyYAML==3.12
 pygerduty==0.37.0

--- a/service_report_generator.py
+++ b/service_report_generator.py
@@ -51,39 +51,32 @@ import json
 import argparse
 from collections import defaultdict
 
-STATUSES_TO_LIST = ['fail', 'warn', 'err']
+STATUSES_TO_LIST = ["fail", "warn", "err"]
 
 service_json_template = {
-    'name': 'pytest',
-    'tool_url': 'https://github.com/mozilla-services/pytest-services',
-    'version': 1,
-    'created_at': '',
-    'meanings': {
-        'pass': {
-            'short': 'Pass',
-            'long': 'Test passed / no issues found.'
+    "name": "pytest",
+    "tool_url": "https://github.com/mozilla-services/pytest-services",
+    "version": 1,
+    "created_at": "",
+    "meanings": {
+        "pass": {"short": "Pass", "long": "Test passed / no issues found."},
+        "warn": {
+            "short": "Warn",
+            "long": "Expected test failures, either due to test-level "
+            "xfail/xpass markers or exemptions.",
         },
-        'warn': {
-            'short': 'Warn',
-            'long': 'Expected test failures, either due to test-level '
-            'xfail/xpass markers or exemptions.'
+        "fail": {
+            "short": "FAIL",
+            "long": "Critical test failure that should never happen "
+            "e.g. publicly accessible DB snapshot, user without MFA in prod.",
         },
-        'fail': {
-            'short': 'FAIL',
-            'long': 'Critical test failure that should never happen '
-            'e.g. publicly accessible DB snapshot, user without MFA in prod.'
-        },
-        'err': {
-            'short': 'Err',
-            'long': 'Error fetching an resource from AWS.'
-        }
+        "err": {"short": "Err", "long": "Error fetching an resource from AWS."},
     },
-    'results': []
+    "results": [],
 }
 
 
 class ReportGenerator:
-
     def __init__(self, service_json, fout=None):
         self.fout = fout
 
@@ -93,10 +86,12 @@ class ReportGenerator:
         # {'test_name_fail': 2, ...}
         self.test_status_counter = defaultdict(int)
 
-        for result in service_json['results']:
-            if result['status'] in STATUSES_TO_LIST and result['severity'] != 'INFO':
-                self.test_results[result['test_name']].append(result)
-                self.test_status_counter[result['test_name']+"_"+result['status']] += 1
+        for result in service_json["results"]:
+            if result["status"] in STATUSES_TO_LIST and result["severity"] != "INFO":
+                self.test_results[result["test_name"]].append(result)
+                self.test_status_counter[
+                    result["test_name"] + "_" + result["status"]
+                ] += 1
 
     def generate(self):
         self.print_header()
@@ -116,49 +111,53 @@ class ReportGenerator:
         >>> MarkdownReportGenerator({'results': []})._format_metadata({'VpcId': '1234', 'GroupName': 'ssh-only'})
         'GroupName: ssh-only - VpcId: 1234'
         """
-        return ''.join(["{}: {} - ".format(k, v) for k, v in sorted(metadata.items())])[0:-3]
+        return "".join(["{}: {} - ".format(k, v) for k, v in sorted(metadata.items())])[
+            0:-3
+        ]
 
     # test results include at least one with status of
     def _test_results_include_status(self, test_name, status):
-        return bool(self.test_status_counter[test_name+'_'+status])
+        return bool(self.test_status_counter[test_name + "_" + status])
 
     def _get_resource_type(self, test_name):
-        if 'rds' in test_name:
-            return 'RDS'
-        if 'security_group' in test_name:
-            return 'Security Group'
-        if 'iam' in test_name:
-            return 'IAM'
-        return ''
+        if "rds" in test_name:
+            return "RDS"
+        if "security_group" in test_name:
+            return "Security Group"
+        if "iam" in test_name:
+            return "IAM"
+        return ""
 
     def _get_resource_id(self, resource_type, resource_name, result_metadata):
         if resource_type == "Security Group":
             return resource_name.split(" ")[0]
         if resource_type == "RDS":
-            return result_metadata.get('DBInstanceIdentifier')
-        return ''
+            return result_metadata.get("DBInstanceIdentifier")
+        return ""
 
     def _get_tag_value(self, tag_key, result_metadata):
-        if result_metadata.get('TagList'):
-            for tag in result_metadata['TagList']:
-                if tag['Key'] == tag_key:
-                    return tag['Value']
-        if result_metadata.get('Tags'):
-            for tag in result_metadata['Tags']:
-                if tag['Key'] == tag_key:
-                    return tag['Value']
-        return ''
+        if result_metadata.get("TagList"):
+            for tag in result_metadata["TagList"]:
+                if tag["Key"] == tag_key:
+                    return tag["Value"]
+        if result_metadata.get("Tags"):
+            for tag in result_metadata["Tags"]:
+                if tag["Key"] == tag_key:
+                    return tag["Value"]
+        return ""
 
     def _get_region(self, result_metadata):
-        if result_metadata.get('__pytest_meta'):
-            return result_metadata['__pytest_meta'].get("region", "")
-        return ''
+        if result_metadata.get("__pytest_meta"):
+            return result_metadata["__pytest_meta"].get("region", "")
+        return ""
 
 
 class CsvReportGenerator(ReportGenerator):
-
     def print_header(self):
-        print("Test Name,Resource Type,Resource Id,Resource Name,Region,App,Owner,Assignee", file=self.fout)
+        print(
+            "Test Name,Resource Type,Resource Id,Resource Name,Region,App,Owner,Assignee",
+            file=self.fout,
+        )
 
     def print_table_of_contents(self):
         return
@@ -176,7 +175,7 @@ class CsvReportGenerator(ReportGenerator):
                 if result["status"] != status:
                     continue
 
-                resource_name = self._extract_resource_name(result['name'])
+                resource_name = self._extract_resource_name(result["name"])
 
                 rtype = self._get_resource_type(test_name)
 
@@ -187,25 +186,28 @@ class CsvReportGenerator(ReportGenerator):
                 rid = self._get_resource_id(rtype, resource_name, result)
 
                 # Get App and Owner Tag
-                app = self._get_tag_value('App', result['metadata'])
-                owner = self._get_tag_value('Owner', result['metadata'])
+                app = self._get_tag_value("App", result["metadata"])
+                owner = self._get_tag_value("Owner", result["metadata"])
 
                 # Get Region
-                region = self._get_region(result['metadata'])
+                region = self._get_region(result["metadata"])
 
-                print("%s,%s,%s,%s,%s,%s,%s," % (
-                    test_name,
-                    rtype,
-                    rid,
-                    display_resource_name,
-                    region,
-                    app,
-                    owner
-                ), file=self.fout)
+                print(
+                    "%s,%s,%s,%s,%s,%s,%s,"
+                    % (
+                        test_name,
+                        rtype,
+                        rid,
+                        display_resource_name,
+                        region,
+                        app,
+                        owner,
+                    ),
+                    file=self.fout,
+                )
 
 
 class MarkdownReportGenerator(ReportGenerator):
-
     def print_header(self):
         print("# AWS pytest-services results\n", file=self.fout)
         print("#### Status Meanings: \n", file=self.fout)
@@ -217,19 +219,23 @@ class MarkdownReportGenerator(ReportGenerator):
             print("- [%s](#%s)" % (test, test), file=self.fout)
             for status in STATUSES_TO_LIST:
                 if self._test_results_include_status(test, status):
-                    print("    - [%s (%s)](#%s)" % (
-                        status,
-                        self.test_status_counter[test+'_'+status],
-                        test+'_'+status,
-                    ), file=self.fout)
+                    print(
+                        "    - [%s (%s)](#%s)"
+                        % (
+                            status,
+                            self.test_status_counter[test + "_" + status],
+                            test + "_" + status,
+                        ),
+                        file=self.fout,
+                    )
         print("---\n", file=self.fout)
 
     def print_report(self):
         for test in self.test_results:
             self._print_test_header(
                 test,
-                self.test_results[test][0]['description'],
-                self.test_results[test][0]['rationale']
+                self.test_results[test][0]["description"],
+                self.test_results[test][0]["rationale"],
             )
 
             self._print_test_result_tables(test)
@@ -252,21 +258,31 @@ class MarkdownReportGenerator(ReportGenerator):
 
                 for result in self.test_results[test_name]:
                     if result["status"] == status:
-                        print("%s | %s" % (
-                            self._extract_resource_name(result['name']),
-                            self._format_metadata(result['metadata'])
-                        ), file=self.fout)
+                        print(
+                            "%s | %s"
+                            % (
+                                self._extract_resource_name(result["name"]),
+                                self._format_metadata(result["metadata"]),
+                            ),
+                            file=self.fout,
+                        )
 
                 print("\n\n", file=self.fout)
 
     def _print_status_table(self):
         print("Status Name | Meaning", file=self.fout)
         print("------------ | -------------", file=self.fout)
-        print("fail | Critical test failure that should never happen e.g. publicly "
-              "accessible DB snapshot, user without MFA in prod.", file=self.fout)
-        print("warn | Non-critical test result like an unexpected test failure "
-              "(xpass, xfail, skip). Examples: S3 bucket not tagged as public, "
-              "error fetching resource from the AWS API, test skipped due to it not applying", file=self.fout)
+        print(
+            "fail | Critical test failure that should never happen e.g. publicly "
+            "accessible DB snapshot, user without MFA in prod.",
+            file=self.fout,
+        )
+        print(
+            "warn | Non-critical test result like an unexpected test failure "
+            "(xpass, xfail, skip). Examples: S3 bucket not tagged as public, "
+            "error fetching resource from the AWS API, test skipped due to it not applying",
+            file=self.fout,
+        )
         print("err | Error fetching an resource from AWS.", file=self.fout)
         print("\n\n", file=self.fout)
 
@@ -274,76 +290,94 @@ class MarkdownReportGenerator(ReportGenerator):
 def parse_args():
     parser = argparse.ArgumentParser(description=__doc__)
 
-    parser.add_argument('--jo', '--json-out', default='service-report.json',
-                        dest='json_out', help='Service json output filename.')
+    parser.add_argument(
+        "--jo",
+        "--json-out",
+        default="service-report.json",
+        dest="json_out",
+        help="Service json output filename.",
+    )
 
-    parser.add_argument('--mo', '--markdown-out', default='service-report.md',
-                        dest='markdown_out', help='Service markdown output filename.')
+    parser.add_argument(
+        "--mo",
+        "--markdown-out",
+        default="service-report.md",
+        dest="markdown_out",
+        help="Service markdown output filename.",
+    )
 
-    parser.add_argument('--co', '--csv-out', default='service-report.csv',
-                        dest='csv_out', help='Service csv output filename.')
+    parser.add_argument(
+        "--co",
+        "--csv-out",
+        default="service-report.csv",
+        dest="csv_out",
+        help="Service csv output filename.",
+    )
 
-    parser.add_argument('pytest_json', metavar='<pytest-results.json>',
-                        help='Pytest results output in JSON format.')
+    parser.add_argument(
+        "pytest_json",
+        metavar="<pytest-results.json>",
+        help="Pytest results output in JSON format.",
+    )
 
     return parser.parse_args()
 
 
 def get_test_status(outcome):
-    if outcome == 'errored':
-        return 'err'
-    elif outcome in ['xfailed', 'xpassed']:
-        return 'warn'
-    elif outcome in ['passed', 'skipped']:
-        return 'pass'
-    elif outcome == 'failed':
-        return 'fail'
+    if outcome == "errored":
+        return "err"
+    elif outcome in ["xfailed", "xpassed"]:
+        return "warn"
+    elif outcome in ["passed", "skipped"]:
+        return "pass"
+    elif outcome == "failed":
+        return "fail"
     else:
-        raise Exception('Unexpected test outcome %s' % outcome)
+        raise Exception("Unexpected test outcome %s" % outcome)
 
 
 def get_result_for_test(test):
-    meta = test['metadata'][0]
+    meta = test["metadata"][0]
     return {
-        'test_name': meta['unparametrized_name'],
-        'name': meta['parametrized_name'],
-        'status': get_test_status(meta['outcome']),
-        'value': meta['outcome'],
-        'reason': meta['reason'],
-        'markers': meta['markers'],
-        'metadata': meta['metadata'],
-        'rationale': meta['rationale'],
-        'description': meta['description'],
-        'severity': meta['severity'],
-        'regression': meta['regression'],
+        "test_name": meta["unparametrized_name"],
+        "name": meta["parametrized_name"],
+        "status": get_test_status(meta["outcome"]),
+        "value": meta["outcome"],
+        "reason": meta["reason"],
+        "markers": meta["markers"],
+        "metadata": meta["metadata"],
+        "rationale": meta["rationale"],
+        "description": meta["description"],
+        "severity": meta["severity"],
+        "regression": meta["regression"],
     }
 
 
 def pytest_json_to_service_json(pytest_json):
-    service_json_template['created_at'] = pytest_json['report']['created_at']
-    service_json_template['results'] = []
+    service_json_template["created_at"] = pytest_json["report"]["created_at"]
+    service_json_template["results"] = []
 
-    for test in pytest_json['report']['tests']:
+    for test in pytest_json["report"]["tests"]:
         try:
-            service_json_template['results'].append(get_result_for_test(test))
+            service_json_template["results"].append(get_result_for_test(test))
         except KeyError:
             pass
 
     return service_json_template
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     args = parse_args()
 
-    pytest_json = json.load(open(args.pytest_json, 'r'))
+    pytest_json = json.load(open(args.pytest_json, "r"))
 
     service_json = pytest_json_to_service_json(pytest_json)
 
-    with open(args.json_out, 'w') as fout:
+    with open(args.json_out, "w") as fout:
         json.dump(service_json, fout, sort_keys=True, indent=4)
 
-    with open(args.markdown_out, 'w') as fout:
+    with open(args.markdown_out, "w") as fout:
         MarkdownReportGenerator(service_json, fout=fout).generate()
 
-    with open(args.csv_out, 'w') as fout:
+    with open(args.csv_out, "w") as fout:
         CsvReportGenerator(service_json, fout=fout).generate()

--- a/severity.py
+++ b/severity.py
@@ -7,11 +7,7 @@ import pytest
 
 
 # parseable severity levels in order of increasing badness
-SEVERITY_LEVELS = [
-    'INFO',
-    'WARN',
-    'ERROR',
-]
+SEVERITY_LEVELS = ["INFO", "WARN", "ERROR"]
 
 
 def load(rules):
@@ -51,21 +47,31 @@ def load(rules):
         return processed_rules
 
     for rule in rules:
-        test_name, severity = rule['test_name'], rule['severity']
+        test_name, severity = rule["test_name"], rule["severity"]
 
         if severity not in SEVERITY_LEVELS:
-            warnings.warn('test_name: {} | Skipping line with invalid severity level {!r}'.format(test_name, severity))
+            warnings.warn(
+                "test_name: {} | Skipping line with invalid severity level {!r}".format(
+                    test_name, severity
+                )
+            )
             continue
 
         if test_name in processed_rules:
-            warnings.warn('test_name: {} | Skipping line with duplicate test name'.format(test_name))
+            warnings.warn(
+                "test_name: {} | Skipping line with duplicate test name".format(
+                    test_name
+                )
+            )
             continue
 
         processed_rules[test_name] = severity
 
-    if '*' in processed_rules:
-        rules_with_default = defaultdict(lambda: processed_rules['*'], **processed_rules)
-        del rules_with_default['*']
+    if "*" in processed_rules:
+        rules_with_default = defaultdict(
+            lambda: processed_rules["*"], **processed_rules
+        )
+        del rules_with_default["*"]
         return rules_with_default
     else:
         return processed_rules
@@ -83,7 +89,10 @@ def add_severity_marker(item):
         conf_severity = item.config.custom_config.severities[test_name_for_matching]
         test_severity = item.get_marker("severity")
         if test_severity and test_severity.args[0] != conf_severity:
-            warnings.warn('Overriding existing severity {} for test {}'.format(
-                test_severity, test_name_for_matching))
+            warnings.warn(
+                "Overriding existing severity {} for test {}".format(
+                    test_severity, test_name_for_matching
+                )
+            )
 
         item.add_marker(pytest.mark.severity(conf_severity))


### PR DESCRIPTION
Change to using `black`

https://github.com/mozilla-services/pytest-services/commit/ccbc16f90f90ed9a774965662cfe287082b91789 - Adds `make black` and changes travis ci config to use it instead of flake8
https://github.com/mozilla-services/pytest-services/commit/3a6be9ff13d49f71f1eecf4263d625fe0e8781e6 - Reformats the codebase using `black`