### PR TITLE
Fix conftest imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: python
 python:
   - "3.6"
+sudo: required
+
+before_install:
+   - curl -LO https://github.com/BurntSushi/ripgrep/releases/download/0.8.1/ripgrep_0.8.1_amd64.deb
+   - sudo dpkg -i ripgrep_0.8.1_amd64.deb
 
 install:
   - make install
 
 script:
-  - make doctest coverage black
+  - make black check_conftest_imports doctest coverage

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ ifeq ($(VIRTUAL_ENV),)
 	$(error "Run pytest-services from a virtualenv (try 'make install && source venv/bin/activate')")
 endif
 
+check_conftest_imports:
+	# refs: https://github.com/mozilla-services/pytest-services/issues/119
+	rg '^import\s+conftest|^from\s+conftest\s+import\s+pytest' -g '*.py'; [ $$? -eq 1 ]
+
 clean: clean-cache clean-python
 	rm -rf venv
 	# remember to deactivate your active virtual env
@@ -64,6 +68,7 @@ venv:
 .PHONY:
 	all \
 	check_venv \
+	check_conftest_imports \
 	clean \
 	clean-cache \
 	clean-python \


### PR DESCRIPTION
fixes: #119 

Add checks for the patterns in https://github.com/mozilla-services/pytest-services/issues/119#issuecomment-391153748

NB: This requires ripgrep which might not be installed in CI.

Functional Tests:

- [x] Add `import conftest` to a file and check that `make check_conftest_imports` errors

- [x] Add `from conftest import ` to a file and check that `make check_conftest_imports` errors

- [x] Run on master and check that `make check_conftest_imports` does not error