### PR TITLE
Add test_ec2_instance_running_required_amis test

### DIFF
--- a/aws/ec2/test_ec2_instance_running_required_amis.py
+++ b/aws/ec2/test_ec2_instance_running_required_amis.py
@@ -1,0 +1,25 @@
+import pytest
+
+from aws.ec2.helpers import ec2_instance_test_id
+from aws.ec2.resources import ec2_instances
+
+
+@pytest.fixture
+def required_amis(pytestconfig):
+    return frozenset(pytestconfig.custom_config.aws.required_amis)
+
+
+@pytest.mark.ec2
+@pytest.mark.parametrize("ec2_instance", ec2_instances(), ids=ec2_instance_test_id)
+def test_ec2_instance_running_required_amis(ec2_instance, required_amis):
+    """
+    Checks that all EC2 instances are running the required AMIs.
+    """
+    if len(required_amis) == 0:
+        pytest.skip("No required AMIs were provided")
+
+    assert (
+        ec2_instance["ImageId"] in required_amis
+    ), "EC2 Instance {0[InstanceId]} is running unexpected AMI: {0[ImageId]}".format(
+        ec2_instance
+    )

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -36,6 +36,9 @@ aws:
     - Type
     - App
     - Env
+  required_amis:
+    - ami-00000000000000000
+    - ami-55555555555555555
   whitelisted_ports_global:
     - 25
   whitelisted_ports:

--- a/custom_config.py
+++ b/custom_config.py
@@ -60,6 +60,7 @@ class CustomConfigMixin:
 class AWSConfig(CustomConfigMixin):
     def __init__(self, config):
         self.required_tags = frozenset(config.get("required_tags", []))
+        self.required_amis = frozenset(config.get("required_amis", []))
         self.whitelisted_ports_global = set(config.get("whitelisted_ports_global", []))
         self.whitelisted_ports = config.get("whitelisted_ports", [])
         self.access_key_expires_after = config.get("access_key_expires_after", None)


### PR DESCRIPTION
Adds a test that will check that all running EC2 instances are using an
AMI in the "required_amis" list within the provided config file. If no AMIs
exist in this list, skip all of the tests.

r? @psiinon @g-k 