### PR TITLE
Fix the concept of "admin" in aws iam tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,17 +211,27 @@ regressions:
     test_param_id: '*mycustomgroup'
     comment: this was remediated by ops team
 aws:
+  admin_groups:
+    - "Administrators"
+  admin_policies:
+    - "AWSAdminRequireMFA"
   user_is_inactive:
     no_activity_since:
       years: 1
       months: 0
     created_after:
       weeks: 1
+  access_key_expires_after:
+    years: 1
+    months: 0
   required_tags:
     - Name
     - Type
     - App
     - Env
+  required_amis:
+    - ami-00000000000000000
+    - ami-55555555555555555
   whitelisted_ports_global:
     - 25
   whitelisted_ports:
@@ -229,6 +239,12 @@ aws:
       ports:
         - 22
         - 2222
+gsuite:
+  domain: 'example.com'
+  user_is_inactive:
+    no_activity_since:
+      years: 1
+      months: 0
 pagerduty:
   users_with_remote_access_monitoring: 'pd_users.json'
   bastion_users: 'hierahash/*hierahash.json'

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -22,6 +22,10 @@ regressions:
     test_param_id: '*mycustomgroup'
     comment: this was remediated by ops team
 aws:
+  admin_groups:
+    - "Administrators"
+  admin_policies:
+    - "AWSAdminRequireMFA"
   user_is_inactive:
     no_activity_since:
       years: 1

--- a/custom_config.py
+++ b/custom_config.py
@@ -64,6 +64,8 @@ class AWSConfig(CustomConfigMixin):
         self.whitelisted_ports_global = set(config.get("whitelisted_ports_global", []))
         self.whitelisted_ports = config.get("whitelisted_ports", [])
         self.access_key_expires_after = config.get("access_key_expires_after", None)
+        self.admin_policies = frozenset(config.get("admin_policies", []))
+        self.admin_groups = frozenset(config.get("admin_groups", []))
         super().__init__(config)
 
     def get_whitelisted_ports(self, test_id):


### PR DESCRIPTION
Originally, a user was an "admin" if they had a policy that included the
word "admin" in it. That kinda worked sometimes, but needed to be
replaced.

Now, in the config file you can list the admin policies and groups and a
user or role will be matched against these lists.

This PR also updates the `config.yaml` example in the README.