### PR TITLE
Initial pass on refreshing GCP tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,17 @@ The below policy will allow you to run all AWS tests in pytest-services against 
 }
 ```
 
+#### Setting up GCP tests
+
+##### Enabling required API's for your project
+
+```
+gcloud [--project <project name>] services enable bigquery-json.googleapis.com
+gcloud [--project <project name>] services enable cloudresourcemanager.googleapis.com
+gcloud [--project <project name>] services enable compute.googleapis.com
+gcloud [--project <project name>] services enable sqladmin.googleapis.com
+```
+
 #### Setting up GSuite tests
 
 Make sure to have an OAuth2 app created and have the `client_secret.json` file in `~/.credentials` and then run:

--- a/conftest.py
+++ b/conftest.py
@@ -104,13 +104,16 @@ def pytest_configure(config):
 
     config.custom_config = custom_config.CustomConfig(config.getoption("--config"))
 
-    if any(x for x in config.args if "gsuite" in x):
-        gsuite_client = GsuiteClient(
-            domain=config.custom_config.gsuite.domain,
-            offline=config.getoption("--offline"),
-        )
-    else:
-        gsuite_client = GsuiteClient(domain="", offline=True)
+    try:
+        if any(x for x in config.args if "gsuite" in x):
+            gsuite_client = GsuiteClient(
+                domain=config.custom_config.gsuite.domain,
+                offline=config.getoption("--offline"),
+            )
+        else:
+            gsuite_client = GsuiteClient(domain="", offline=True)
+    except AttributeError as e:
+        pass
 
 
 @pytest.fixture

--- a/gcp/client.py
+++ b/gcp/client.py
@@ -1,4 +1,3 @@
-
 from apiclient.discovery import build as build_service
 
 
@@ -18,6 +17,16 @@ class GCPClient:
         if self.offline:
             return "test"
         return self.project_id
+
+    def get_project_iam_policy(self):
+        if self.offline:
+            return {}
+
+        service = self._service("cloudresourcemanager")
+        request = service.projects().getIamPolicy(
+            resource=self.get_project_id(), body={}
+        )
+        return request.execute()
 
     def list(
         self, product, subproduct, version="v1", results_key="items", call_kwargs=None

--- a/gcp/compute/helpers.py
+++ b/gcp/compute/helpers.py
@@ -1,3 +1,36 @@
+def does_firewall_open_all_ports_to_any(firewall):
+    """
+    Returns True if firewall has a rule to open all ports to any source. Excludes ICMP.
+
+    >>> does_firewall_open_all_ports_to_any({})
+    False
+    >>> does_firewall_open_all_ports_to_any({'sourceRanges': ['1.1.1.1/1'], 'allowed': [{'ports': ['1', '2', '300']}]})
+    False
+    >>> does_firewall_open_all_ports_to_any({'sourceRanges': ['1.1.1.1/1'], 'allowed': [{'ports': ['0-65535']}]})
+    True
+    >>> does_firewall_open_all_ports_to_any({'sourceRanges': ['0.0.0.0/0'], 'allowed': [{'ports': ['0-65535']}]})
+    True
+    >>> does_firewall_open_all_ports_to_any({'sourceRanges': ['10.0.0.5/32'], 'allowed': [{'ports': ['0-65535']}]})
+    True
+    """
+    if does_firewall_open_all_ports_to_all(firewall):
+        return True
+
+    if firewall.get("sourceRanges") is None:
+        return False
+
+    for rule in firewall.get("allowed"):
+        if rule.get("IPProtocol", "") == "icmp":
+            continue
+        if not rule.get("ports"):
+            return True
+        for port_rule in rule.get("ports"):
+            if port_rule == "0-65535":
+                return True
+
+    return False
+
+
 def does_firewall_open_all_ports_to_all(firewall):
     """
     Returns True if firewall has a rule to open all ports to all. Excludes ICMP.
@@ -6,9 +39,9 @@ def does_firewall_open_all_ports_to_all(firewall):
     False
     >>> does_firewall_open_all_ports_to_all({'sourceRanges': ['1.1.1.1/1']})
     False
-    >>> does_firewall_open_all_ports_to_all({'sourceRanges': ['1.1.1.1/1'], 'allowed': [{'ports': '0-65535'}]})
+    >>> does_firewall_open_all_ports_to_all({'sourceRanges': ['1.1.1.1/1'], 'allowed': [{'ports': ['0-65535']}]})
     False
-    >>> does_firewall_open_all_ports_to_all({'sourceRanges': ['0.0.0.0/0'], 'allowed': [{'ports': '0-65535'}]})
+    >>> does_firewall_open_all_ports_to_all({'sourceRanges': ['0.0.0.0/0'], 'allowed': [{'ports': ['0-65535']}]})
     True
     """
     if (
@@ -22,12 +55,55 @@ def does_firewall_open_all_ports_to_all(firewall):
             continue
         if not rule.get("ports"):
             return True
-        if rule.get("ports") == "0-65535":
-            return True
+        for port_rule in rule.get("ports"):
+            if port_rule == "0-65535":
+                return True
+
+    return False
+
+
+def does_firewall_open_any_ports_to_all(firewall):
+    """
+    Returns True if firewall has a rule to open any ports (except 80/443) to all. Excludes ICMP.
+
+    >>> does_firewall_open_any_ports_to_all({})
+    False
+    >>> does_firewall_open_any_ports_to_all({'sourceRanges': ['1.1.1.1/1']})
+    False
+    >>> does_firewall_open_any_ports_to_all({'sourceRanges': ['1.1.1.1/1'], 'allowed': [{'ports': ['0-65535']}]})
+    False
+    >>> does_firewall_open_any_ports_to_all({'sourceRanges': ['0.0.0.0/0'], 'allowed': [{'ports': ['0-65535']}]})
+    True
+    >>> does_firewall_open_any_ports_to_all({'sourceRanges': ['1.1.1.1/1'], 'allowed': [{'ports': ['123']}]})
+    False
+    >>> does_firewall_open_any_ports_to_all({'sourceRanges': ['0.0.0.0/0'], 'allowed': [{'ports': ['123']}]})
+    True
+    >>> does_firewall_open_any_ports_to_all({'sourceRanges': ['0.0.0.0/0'], 'allowed': [{'ports': ['80']}]})
+    False
+    >>> does_firewall_open_any_ports_to_all({'sourceRanges': ['0.0.0.0/0'], 'allowed': [{'ports': ['443']}]})
+    False
+    >>> does_firewall_open_any_ports_to_all({'sourceRanges': ['0.0.0.0/0'], 'allowed': [{'ports': ['22', '80', '443']}]})
+    True
+    """
+    if does_firewall_open_all_ports_to_all(firewall):
+        return True
+
+    if (
+        firewall.get("sourceRanges") is None
+        or "0.0.0.0/0" not in firewall["sourceRanges"]
+    ):
+        return False
+
+    for rule in firewall.get("allowed"):
+        if rule.get("IPProtocol", "") == "icmp":
+            continue
+        for port_rule in rule.get("ports"):
+            if port_rule not in ["80", "443"]:
+                return True
 
     return False
 
 
 def firewall_id(firewall):
     """A getter fn for test ids for Firewalls"""
-    return "{} {}".format(firewall["id"], firewall["name"])
+    return "{}-{}".format(firewall["id"], firewall["name"])

--- a/gcp/compute/test_firewall_opens_all_ports_to_any.py
+++ b/gcp/compute/test_firewall_opens_all_ports_to_any.py
@@ -1,0 +1,16 @@
+import pytest
+
+from gcp.compute.helpers import does_firewall_open_all_ports_to_any, firewall_id
+from gcp.compute.resources import in_use_firewalls
+
+
+@pytest.mark.gcp_compute
+@pytest.mark.parametrize("firewall", in_use_firewalls(), ids=firewall_id)
+def test_firewall_opens_all_ports_to_any(firewall):
+    """
+    This test confirms that there are no firewall
+    rules that allow ingress access to all ports from anywhere.
+
+    A part of CIS 3.1
+    """
+    assert not does_firewall_open_all_ports_to_any(firewall)

--- a/gcp/compute/test_firewall_opens_any_ports_to_all.py
+++ b/gcp/compute/test_firewall_opens_any_ports_to_all.py
@@ -1,0 +1,16 @@
+import pytest
+
+from gcp.compute.helpers import does_firewall_open_any_ports_to_all, firewall_id
+from gcp.compute.resources import in_use_firewalls
+
+
+@pytest.mark.gcp_compute
+@pytest.mark.parametrize("firewall", in_use_firewalls(), ids=firewall_id)
+def test_firewall_opens_any_ports_to_all(firewall):
+    """
+    This test confirms that no ports are open to 0.0.0.0/0 (except
+    80 and 443 on any VPC.
+
+    CIS 3.6, 3.7
+    """
+    assert not does_firewall_open_any_ports_to_all(firewall)

--- a/gcp/iam/resources.py
+++ b/gcp/iam/resources.py
@@ -23,3 +23,9 @@ def all_service_account_keys():
     for sa in service_accounts():
         for key in service_account_keys(sa):
             yield key
+
+
+def project_iam_bindings():
+    policy = gcp_client.get_project_iam_policy()
+    for binding in policy.get("bindings", []):
+        yield binding

--- a/gcp/iam/test_admin_service_accounts.py
+++ b/gcp/iam/test_admin_service_accounts.py
@@ -1,0 +1,19 @@
+import pytest
+
+from gcp.iam.resources import project_iam_bindings
+
+
+@pytest.mark.gcp_iam
+@pytest.mark.parametrize("iam_binding", project_iam_bindings(), ids=lambda r: r["role"])
+def test_admin_service_accounts(iam_binding):
+    """
+    No Service Account should have the `role/editor`
+    or `role/owner` roles attached or any roles matching `*Admin`
+
+    CIS 1.4
+    """
+    if (iam_binding["role"] in ["role/editor", "role/owner"]) or (
+        iam_binding["role"].endswith("Admin")
+    ):
+        for member in iam_binding["members"]:
+            assert not member.startswith("serviceAccount")

--- a/gcp/sql/test_sql_instance_private_ip_required.py
+++ b/gcp/sql/test_sql_instance_private_ip_required.py
@@ -1,0 +1,27 @@
+import pytest
+
+from gcp.sql.resources import instances
+
+
+@pytest.mark.gcp_sql
+@pytest.mark.parametrize(
+    "sql_instance", instances(), ids=lambda instance: instance["name"]
+)
+def test_sql_instance_private_ip_required(sql_instance):
+    """
+    Test CloudSQL Instance requires Private IP to connect
+
+    CIS 6.2
+    """
+    assert (
+        sql_instance.get("settings").get("ipConfiguration").get("privateNetwork", None)
+    ), "CloudSQL Instance {0[name]} does not have a private network configured.".format(
+        sql_instance
+    )
+
+    assert (
+        sql_instance.get("settings").get("ipConfiguration").get("ipv4Enabled", None)
+        == False
+    ), "CloudSQL Instance {0[name]} has a public IPv4 enabled.".format(
+        sql_instance
+    )

--- a/gcp/sql/test_sql_instance_ssl_required.py
+++ b/gcp/sql/test_sql_instance_ssl_required.py
@@ -9,4 +9,6 @@ from gcp.sql.resources import instances
 )
 def test_sql_instance_ssl_required(sql_instance):
     """Test CloudSQL Instance requires SSL"""
-    assert sql_instance.get("settings").get("ipConfiguration").get("requireSsl")
+    assert (
+        sql_instance.get("settings").get("ipConfiguration").get("requireSsl", False)
+    ), "CloudSQL Instance {0[name]} does not require SSL".format(sql_instance)


### PR DESCRIPTION
Adds:
  * `test_firewall_opens_all_ports_to_any`
  * `test_firewall_opens_any_ports_to_all`
  * `test_admin_service_accounts`
  * `test_sql_instance_private_ip_required`
  * Initial GCP docs in README

Improve:
  * Fix error within conftest when no args are provided to pytest
  * Add error message to `test_sql_instance_ssl_required`