### PR TITLE
Add new gcp tests, update service_report_generator for gcp

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -50,8 +50,11 @@ aws:
   max_ami_age_in_days: 90
   owned_ami_account_ids:
     - 1234567890
+gcp:
+  allowed_org_domains:
+    - mygsuiteorg.com
 gsuite:
-  domain: 'example.com'
+  domain: 'mygsuiteorg.com'
   min_number_of_owners: 2
   user_is_inactive:
     no_activity_since:

--- a/conftest.py
+++ b/conftest.py
@@ -153,6 +153,8 @@ METADATA_KEYS = [
     "projectId",
     "uniqueId",
     "id",
+    "members",
+    "role",
 ]
 
 

--- a/custom_config.py
+++ b/custom_config.py
@@ -16,6 +16,7 @@ class CustomConfig:
             yaml = YAML()
             parsed_config = yaml.load(config_fd)
         self.aws = AWSConfig(parsed_config.get("aws", {}))
+        self.gcp = GCPConfig(parsed_config.get("gcp", {}))
         self.gsuite = GSuiteConfig(parsed_config.get("gsuite", {}))
         self.pagerduty = PagerdutyConfig(parsed_config.get("pagerduty", {}))
 
@@ -100,6 +101,11 @@ class AWSConfig(CustomConfigMixin):
             months=+self.access_key_expires_after.get("months", 0),
             weeks=+self.access_key_expires_after.get("weeks", 0),
         )
+
+
+class GCPConfig:
+    def __init__(self, config):
+        self.allowed_org_domains = config.get("allowed_org_domains", [])
 
 
 class GSuiteConfig(CustomConfigMixin):

--- a/gcp/client.py
+++ b/gcp/client.py
@@ -33,6 +33,15 @@ class GCPClient:
         )
         return request.execute()
 
+    def get_project_container_config(self):
+        if self.offline:
+            return {}
+
+        service = self._service("container")
+        name = "projects/" + self.get_project_id() + "/locations/us-west1"
+        request = service.projects().locations().getServerConfig(name=name)
+        return request.execute()
+
     def get(
         self, product, subproduct, id_key, id_value, version="v1", call_kwargs=None
     ):

--- a/gcp/compute/resources.py
+++ b/gcp/compute/resources.py
@@ -13,6 +13,16 @@ def instances():
     return gcp_client.list("compute", "instances")
 
 
+def clusters():
+    parent = "projects/" + gcp_client.get_project_id() + "/locations/-"
+    return gcp_client.list(
+        "container",
+        "projects.locations.clusters",
+        results_key="clusters",
+        call_kwargs={"parent": parent},
+    )
+
+
 def networks_with_instances():
     for network in networks():
         network["instances"] = []

--- a/gcp/compute/test_gke_version_up_to_date.py
+++ b/gcp/compute/test_gke_version_up_to_date.py
@@ -1,0 +1,29 @@
+import pytest
+
+from gcp.compute.resources import clusters
+from conftest import gcp_client
+
+
+@pytest.fixture
+def server_config():
+    return gcp_client.get_project_container_config()
+
+
+@pytest.mark.gcp_compute
+@pytest.mark.parametrize("cluster", clusters(), ids=lambda c: c["name"])
+def test_gke_version_up_to_date(cluster, server_config):
+    """
+    Tests if GKE version is up to date by comparing the
+    list of valid master and node versions to what is
+    currently running on the cluster.
+    """
+    assert (
+        cluster["currentMasterVersion"] in server_config["validMasterVersions"]
+    ), "Current GKE master version ({}) is not in the list of valid master versions.".format(
+        cluster["currentMasterVersion"]
+    )
+    assert (
+        cluster["currentNodeVersion"] in server_config["validNodeVersions"]
+    ), "Current GKE node version ({}) is not in the list of valid node versions.".format(
+        cluster["currentNodeVersion"]
+    )

--- a/gcp/iam/test_only_allowed_org_accounts.py
+++ b/gcp/iam/test_only_allowed_org_accounts.py
@@ -28,4 +28,6 @@ def test_only_allowed_org_accounts(iam_binding, allowed_org_domains):
             if not member.startswith("serviceAccount"):
                 assert (
                     member.split("@")[-1] in allowed_org_domains
-                ), "{} was found and is not in the allowed_org_domains".format(member)
+                ), "{} was found and is not in the allowed_org_domains".format(
+                    member
+                )

--- a/gcp/iam/test_only_allowed_org_accounts.py
+++ b/gcp/iam/test_only_allowed_org_accounts.py
@@ -1,0 +1,31 @@
+import pytest
+
+from gcp.iam.resources import project_iam_bindings
+
+
+@pytest.fixture
+def allowed_org_domains(pytestconfig):
+    return pytestconfig.custom_config.gcp.allowed_org_domains
+
+
+EXCLUDED_ROLES = ["roles/logging.viewer"]
+
+
+@pytest.mark.gcp_iam
+@pytest.mark.parametrize("iam_binding", project_iam_bindings(), ids=lambda r: r["role"])
+def test_only_allowed_org_accounts(iam_binding, allowed_org_domains):
+    """
+    Only allow specified org domains as members within this project, with a few exceptions.
+        * Service Accounts are excluded
+        * The following roles are excluded:
+            - roles/logging.viewer
+    """
+    if len(allowed_org_domains) == 0:
+        assert False, "No allowed org domains specified"
+
+    if iam_binding["role"] not in EXCLUDED_ROLES:
+        for member in iam_binding["members"]:
+            if not member.startswith("serviceAccount"):
+                assert (
+                    member.split("@")[-1] in allowed_org_domains
+                ), "{} was found and is not in the allowed_org_domains".format(member)


### PR DESCRIPTION
Adds two new tests:
  * test_only_allowed_org_accounts - Confirms that only approved domains/gsuites have access to projects (with a list of role exceptions, e.g. log viewer)
  * test_gke_version_up_to_date - Confirms GKE Clusters master and node versions are in the list of valid versions.

Also adds basic support for GCP CSV reports via `service_report_generator.py`