### PR TITLE
Move black to pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+-   repo: https://github.com/python/black
+    rev: 18.6b4
+    hooks:
+    - id: black
+      language_version: python3.6

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,11 @@ clean: clean-cache clean-python
 	# remember to deactivate your active virtual env
 
 clean-cache: check_venv
-	pytest --cache-clear --offline
+	@# do as little work as possible to clear the cache, and guarantee success
+	pytest --cache-clear --continue-on-collection-errors \
+		--collect-only -m "no_such_marker" \
+		--noconftest --tb=no --disable-warnings --quiet \
+	    || true
 
 clean-python:
 	find . -type d -name venv -prune -o -type d -name __pycache__ -print0 | xargs -0 rm -rf
@@ -49,10 +53,10 @@ flake8: check_venv
 	flake8 --max-line-length 120 $(shell git ls-files | grep \.py$$)
 
 black: check_venv
-	black --check $(shell git ls-files | grep \.py$$)
+	pre-commit run black --all-files
 
 install: venv
-	( . venv/bin/activate && pip install -U pip && pip install -r requirements.txt )
+	( . venv/bin/activate && pip install -U pip && pip install -r requirements.txt  && pre-commit install )
 
 setup_gsuite: check_venv
 	python -m bin.auth.setup_gsuite

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-black==18.6b4
 botocore==1.12.75
 coverage==4.5.3
 google_api_python_client==1.6.1
@@ -9,5 +8,6 @@ pytest-metadata==1.8.0
 pytest==3.10.1
 python-dateutil==2.7.5
 git+https://github.com/hwine/python-herokuadmintools.git#egg=herokuadmintools
+pre-commit==1.17.0
 ruamel.yaml==0.15.85
 wheel==0.33.1


### PR DESCRIPTION
Fixes #272

Goal is to reduce impact of differing versions of black between this repo's venv and developer tooling. We now use pre-commit to enforce consistency.
 - pinning of black version moves from requirements.txt to .pre-commit-config.yaml.
 - pre-commit is added to requirements.txt, and black removed
  - makefile targets modified to ensure pre-commit init is run.
