### PR TITLE
Add test for publicly available ebs snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ The below policy will allow you to run all AWS tests in pytest-services against 
         "ec2:DescribeFlowLogs",
         "ec2:DescribeInstances",
         "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSnapshotAttribute",
+        "ec2:DescribeSnapshots",
         "ec2:DescribeVolumes",
         "ec2:DescribeVpcs",
         "elasticache:DescribeCacheClusters",

--- a/aws/ec2/helpers.py
+++ b/aws/ec2/helpers.py
@@ -293,6 +293,27 @@ def is_ebs_volume_encrypted(ebs):
     return ebs["Encrypted"]
 
 
+def is_ebs_snapshot_public(ebs_snapshot):
+    """
+    Checks if the EBS snapshot's 'CreateVolumePermissions' attribute allows for public creation.
+
+    >>> is_ebs_snapshot_public({'CreateVolumePermissions':[{'Group': 'all'}]})
+    True
+    >>> is_ebs_snapshot_public({'CreateVolumePermissions':[{'Group': ''}]})
+    False
+    >>> is_ebs_snapshot_public({'CreateVolumePermissions':[{'foo': 'bar'}]})
+    False
+    >>> is_ebs_snapshot_public({'CreateVolumePermissions':[]})
+    False
+    >>> is_ebs_snapshot_public({})
+    False
+    """
+    for p in ebs_snapshot.get("CreateVolumePermissions", []):
+        if p.get("Group", "") == "all":
+            return True
+    return False
+
+
 def ec2_instance_missing_tag_names(ec2_instance, required_tag_names):
     """
     Returns any tag names that are missing from an EC2 Instance.

--- a/aws/ec2/resources.py
+++ b/aws/ec2/resources.py
@@ -52,6 +52,36 @@ def ec2_ebs_volumes():
     )
 
 
+def ec2_ebs_snapshots():
+    "http://botocore.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.describe_snapshots"
+    return (
+        botocore_client.get("ec2", "describe_snapshots", [], {"OwnerIds": ["self"]})
+        .extract_key("Snapshots")
+        .flatten()
+        .values()
+    )
+
+
+def ec2_ebs_snapshots_create_permission():
+    "https://botocore.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_snapshot_attribute"
+    return sum(
+        [
+            botocore_client.get(
+                service_name="ec2",
+                method_name="describe_snapshot_attribute",
+                call_args=[],
+                call_kwargs={
+                    "Attribute": "createVolumePermission",
+                    "SnapshotId": snapshot["SnapshotId"],
+                },
+                regions=[snapshot["__pytest_meta"]["region"]],
+            ).values()
+            for snapshot in ec2_ebs_snapshots()
+        ],
+        [],
+    )
+
+
 def ec2_flow_logs():
     "https://botocore.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.describe_flow_logs"
     return (

--- a/aws/ec2/test_ec2_ebs_snapshots_are_private.py
+++ b/aws/ec2/test_ec2_ebs_snapshots_are_private.py
@@ -1,0 +1,16 @@
+import pytest
+
+from aws.ec2.resources import ec2_ebs_snapshots_create_permission
+from aws.ec2.helpers import is_ebs_snapshot_public
+
+
+@pytest.mark.ec2
+@pytest.mark.parametrize(
+    "ec2_ebs_snapshot",
+    ec2_ebs_snapshots_create_permission(),
+    ids=lambda ebs: ebs["SnapshotId"],
+)
+def test_ec2_ebs_snapshot_are_private(ec2_ebs_snapshot):
+    assert not is_ebs_snapshot_public(
+        ec2_ebs_snapshot
+    ), "Snapshot {} is publicly accessible.".format(ec2_ebs_snapshot["SnapshotId"])


### PR DESCRIPTION
Adds a new test for publicly available EBS snapshots.

Docs/Reference:
https://techcrunch.com/2019/08/09/aws-ebs-cloud-backups-leak/
https://www.cloudconformity.com/conformity-rules/EBS/public-snapshots.html#